### PR TITLE
Use try/catch to return an error message for invalid regular expressions

### DIFF
--- a/integration/live_test.go
+++ b/integration/live_test.go
@@ -94,6 +94,16 @@ func TestKWinWorkflow(t *testing.T) {
 	}
 
 	kwst := buildKWST(t)
+	t.Run("find rejects invalid regular expression", func(t *testing.T) {
+		result := runKWST(t, kwst, "find", "[")
+		if result.exitCode != 1 {
+			t.Fatalf("find with an invalid regular expression returned exit code %d, want 1:\n%s", result.exitCode, result.String())
+		}
+		if !strings.Contains(result.stderr, "Invalid regular expression") {
+			t.Fatalf("find with an invalid regular expression did not report the error:\n%s", result.String())
+		}
+	})
+
 	originalWorkspace := getWorkspace(t, kwst)
 
 	runID := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())

--- a/main_test.go
+++ b/main_test.go
@@ -83,12 +83,55 @@ func TestSearchTermIsEscapedInGeneratedScript(t *testing.T) {
 		t.Fatal(err)
 	}
 	generated := script.String()
-	expected := "const regExp = new RegExp(" + quotedSearchTerm + ", 'i');"
+	expected := "regExp = new RegExp(" + quotedSearchTerm + ", 'i');"
 	if !strings.Contains(generated, expected) {
 		t.Fatalf("generated script does not contain %q:\n%s", expected, generated)
 	}
 	if strings.Contains(generated, "String.raw`") {
 		t.Fatalf("generated script still uses an unsafe template literal:\n%s", generated)
+	}
+}
+
+func TestFindHandlesInvalidRegularExpression(t *testing.T) {
+	params := ScriptParams{
+		SearchTerm:  "[invalid",
+		SearchField: "caption",
+	}
+	tmpl, err := template.New("test").Funcs(template.FuncMap{
+		"jsString": jsString,
+	}).Parse(JS_FIND)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var script strings.Builder
+	if err := tmpl.Execute(&script, params); err != nil {
+		t.Fatal(err)
+	}
+
+	generated := script.String()
+	quotedSearchTerm, err := jsString(params.SearchTerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"let regExp;",
+		"try {",
+		"regExp = new RegExp(" + quotedSearchTerm + ", 'i');",
+		"catch (error)",
+		`returnError("Invalid regular expression: " + error.message);`,
+		"if (regExp)",
+	} {
+		if !strings.Contains(generated, expected) {
+			t.Errorf("generated script does not contain %q:\n%s", expected, generated)
+		}
+	}
+
+	errorHandler := strings.Index(generated, `returnError("Invalid regular expression: " + error.message);`)
+	searchGuard := strings.Index(generated, "if (regExp)")
+	windowSearch := strings.Index(generated, ".search(regExp)")
+	if errorHandler < 0 || searchGuard < errorHandler || windowSearch < searchGuard {
+		t.Errorf("window search is not protected by the regular-expression guard:\n%s", generated)
 	}
 }
 

--- a/scripts.go
+++ b/scripts.go
@@ -51,15 +51,22 @@ var JS_FIND string = `debugLog(scriptName + " executing JS_SEARCH");
 
 const allWindows = workspace.windowList();
 let results = [];
-const regExp = new RegExp({{jsString .SearchTerm}}, 'i');
-for (let i = 0; i < allWindows.length; i++) {
-    let w = allWindows[i];
-    if (w.{{.SearchField}}.search(regExp) >= 0) {
-        results.push(w);
-    }
+let regExp;
+try {
+    regExp = new RegExp({{jsString .SearchTerm}}, 'i');
+} catch (error) {
+    returnError("Invalid regular expression: " + error.message);
 }
-for (let i = 0; i < results.length; i++) {
-    returnResult(results[i].internalId);
+if (regExp) {
+    for (let i = 0; i < allWindows.length; i++) {
+        let w = allWindows[i];
+        if (w.{{.SearchField}}.search(regExp) >= 0) {
+            results.push(w);
+        }
+    }
+    for (let i = 0; i < results.length; i++) {
+        returnResult(results[i].internalId);
+    }
 }
 
 `


### PR DESCRIPTION
RegExp creation is now wrapped in a `try/catch` block to catch errors and prevent unnecessary timeouts.

Fixes #34 