### PR TITLE
previous-window is now an installable KWin script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Here is the list of things that you can currently do with **kwst**:
 - Get the UUID of the active window.
 - Activate a window.
 - Close a window.
-- Switch to the previous window in the window stack (this allows users to quickly switch between two most recently used windows).
 - Get window geometry (size and position).
 - Set window geometry (size and position).
 - Set window properties (such as keepAbove, keepBelow, fullScreen, etc.)
@@ -31,6 +30,13 @@ I personally use (and extensively test) **kwst** in Wayland, but as far as I und
 Run `kwst --help` to get context-sensitive help. Run `kwst <command> --help` for more information on a command.
 
 Also check shell scripts in the `_examples` directory to get an idea of what you can use **kwst** for.
+
+## Optional previous-window shortcut
+
+The [`kwin-previous-window-script`](kwin-previous-window-script/README.md)
+directory contains an optional resident KWin script that tracks window
+activation and provides a shortcut for switching to the previously active
+window. It is installed separately and is not required for any **kwst** command.
 
 ## Exit status
 

--- a/commands.go
+++ b/commands.go
@@ -187,13 +187,6 @@ func (rcsc *RunCustomScriptCmd) Run(sp *ScriptPackage) error {
 	return nil
 }
 
-type PreviousWindowCmd struct{}
-
-func (pwc *PreviousWindowCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_PREVIOUS_WINDOW
-	return nil
-}
-
 type MousePosCmd struct{}
 
 func (mpc *MousePosCmd) Run(sp *ScriptPackage) error {

--- a/integration/live_test.go
+++ b/integration/live_test.go
@@ -123,12 +123,6 @@ func TestKWinWorkflow(t *testing.T) {
 	activateAndVerify(t, kwst, first)
 	activateAndVerify(t, kwst, second)
 
-	requireSuccess(t, runKWST(t, kwst, "previous-window"), "switch to the previous window")
-	eventually(t, "the first fixture to become active again", func() (bool, string) {
-		result := runKWST(t, kwst, "get-active-window")
-		return result.exitCode == 0 && result.stdout == first.uuid, result.String()
-	})
-
 	resizeAndMoveFixture(t, kwst, first)
 
 	t.Run("change active workspace", func(t *testing.T) {

--- a/kwin-previous-window-script/README.md
+++ b/kwin-previous-window-script/README.md
@@ -1,0 +1,21 @@
+# KWST Previous Window KWin script
+
+This optional resident KWin script tracks regular window activation in memory
+and provides the shortcut **[KWST] Switch to previously active window**. No key
+sequence is assigned by default.
+
+Install or replace the user-local package with:
+
+```sh
+./install.sh
+```
+
+After installation, enable **KWST Previous Window** under **System Settings →
+Window Management → KWin Scripts**. Then assign a key sequence to the shortcut
+under **System Settings → Keyboard → Shortcuts → KWin**.
+
+Remove the user-local package with:
+
+```sh
+./uninstall.sh
+```

--- a/kwin-previous-window-script/contents/code/main.js
+++ b/kwin-previous-window-script/contents/code/main.js
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Pavel Urusov
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+const activationHistory = [];
+
+function sameWindow(first, second) {
+    return first.internalId.toString() === second.internalId.toString();
+}
+
+function isTrackable(window) {
+    return window && !window.specialWindow;
+}
+
+function removeFromHistory(window) {
+    if (!window) {
+        return;
+    }
+
+    for (let index = activationHistory.length - 1; index >= 0; index--) {
+        if (sameWindow(activationHistory[index], window)) {
+            activationHistory.splice(index, 1);
+        }
+    }
+}
+
+function recordActivation(window) {
+    if (!isTrackable(window)) {
+        return;
+    }
+
+    removeFromHistory(window);
+    activationHistory.push(window);
+}
+
+function pruneHistory() {
+    const windows = workspace.windowList();
+    for (let index = activationHistory.length - 1; index >= 0; index--) {
+        const window = activationHistory[index];
+        const stillExists = windows.some((candidate) => sameWindow(candidate, window));
+        if (!isTrackable(window) || !stillExists) {
+            activationHistory.splice(index, 1);
+        }
+    }
+}
+
+function switchToPreviouslyActiveWindow() {
+    recordActivation(workspace.activeWindow);
+    pruneHistory();
+
+    const activeWindow = workspace.activeWindow;
+    for (let index = activationHistory.length - 1; index >= 0; index--) {
+        const candidate = activationHistory[index];
+        if (!isTrackable(activeWindow) || !sameWindow(candidate, activeWindow)) {
+            workspace.activeWindow = candidate;
+            return;
+        }
+    }
+}
+
+workspace.windowActivated.connect(recordActivation);
+workspace.windowRemoved.connect(removeFromHistory);
+recordActivation(workspace.activeWindow);
+
+const shortcutName = "[KWST] Switch to previously active window";
+registerShortcut(shortcutName, shortcutName, "", switchToPreviouslyActiveWindow);

--- a/kwin-previous-window-script/install.sh
+++ b/kwin-previous-window-script/install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Pavel Urusov
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -eu
+
+package_id="net.prsv.kwst.previouswindow"
+script_dir=$(dirname -- "$0")
+script_dir=$(CDPATH='' cd -- "$script_dir" && pwd)
+
+if ! kpackage_tool=$(command -v kpackagetool6); then
+    echo "Error: kpackagetool6 is not installed or is not available in PATH." >&2
+    exit 1
+fi
+
+if "$kpackage_tool" --type=KWin/Script --show "$package_id" >/dev/null 2>&1; then
+    "$kpackage_tool" --type=KWin/Script --remove "$package_id"
+fi
+
+"$kpackage_tool" --type=KWin/Script --install "$script_dir"

--- a/kwin-previous-window-script/metadata.json
+++ b/kwin-previous-window-script/metadata.json
@@ -1,0 +1,19 @@
+{
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "31886681+SpinningVinyl@users.noreply.github.com",
+                "Name": "Pavel Urusov"
+            }
+        ],
+        "Description": "Tracks window activation and switches to the previously active window.",
+        "Id": "net.prsv.kwst.previouswindow",
+        "License": "GPL-2.0-or-later",
+        "Name": "KWST Previous Window",
+        "Version": "1.0.0",
+        "Website": "https://github.com/SpinningVinyl/kwst"
+    },
+    "KPackageStructure": "KWin/Script",
+    "X-Plasma-API": "javascript",
+    "X-Plasma-MainScript": "code/main.js"
+}

--- a/kwin-previous-window-script/uninstall.sh
+++ b/kwin-previous-window-script/uninstall.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Pavel Urusov
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -eu
+
+package_id="net.prsv.kwst.previouswindow"
+
+if ! kpackage_tool=$(command -v kpackagetool6); then
+    echo "Error: kpackagetool6 is not installed or is not available in PATH." >&2
+    exit 1
+fi
+
+if "$kpackage_tool" --type=KWin/Script --show "$package_id" >/dev/null 2>&1; then
+    "$kpackage_tool" --type=KWin/Script --remove "$package_id"
+else
+    echo "KWST Previous Window is not installed."
+fi

--- a/kwst.1.scd
+++ b/kwst.1.scd
@@ -82,10 +82,6 @@ to finish returns status 124.
 	*activate-window* <uuid>
 		Activate the window with the provided UUID, if such a window exists.
 
-	*previous-window*
-		Switch to the second most recently active window. This command can be used
-		to quickly switch between two windows.
-
 	*set-window-size* <uuid> <width> <height>
 		Set the size of the window with the provided UUID, provided that
 		such a window exists.		

--- a/main.go
+++ b/main.go
@@ -36,7 +36,6 @@ type CLI struct {
 	GetWorkspace       GetWorkspaceCmd       `cmd:"" help:"Get the ID of the active workspace."`
 	SetWorkspace       SetWorkspaceCmd       `cmd:"" help:"Switch to the workspace with the specified ID."`
 	ActivateWindow     ActivateWindowCmd     `cmd:"" help:"Activate the window with the provided UUID, if such a window exists."`
-	PreviousWindow     PreviousWindowCmd     `cmd:"" help:"Switch to the second most recently active window. This command can be used to quickly switch between two windows."`
 	SetWindowSize      SetWindowSizeCmd      `cmd:"" help:"Set the size of the window with the provided UUID."`
 	SetWindowPosition  SetWindowPosCmd       `cmd:"" help:"Set the position of the window with the provided UUID."`
 	SetWindowGeometry  SetWindowGeometryCmd  `cmd:"" help:"Change geometry of the window with the provided UUID."`

--- a/main_test.go
+++ b/main_test.go
@@ -148,24 +148,6 @@ func TestGetActiveWindowRejectsSpecialWindow(t *testing.T) {
 	}
 }
 
-func TestPreviousWindowGuardsShortWindowStack(t *testing.T) {
-	for _, expected := range []string{
-		"if (windowStack.length < 2)",
-		`returnError("No previous window available");`,
-		"workspace.activeWindow = windowStack[windowStack.length - 2];",
-	} {
-		if !strings.Contains(JS_PREVIOUS_WINDOW, expected) {
-			t.Errorf("JS_PREVIOUS_WINDOW does not contain %q", expected)
-		}
-	}
-
-	guard := strings.Index(JS_PREVIOUS_WINDOW, "if (windowStack.length < 2)")
-	activation := strings.Index(JS_PREVIOUS_WINDOW, "workspace.activeWindow =")
-	if guard < 0 || activation < guard {
-		t.Error("previous-window activation is not protected by the short-stack guard")
-	}
-}
-
 func TestSetWindowWorkspaceGuardsMissingWindow(t *testing.T) {
 	params := ScriptParams{
 		Uuid:        `missing\"; malicious(); //`,

--- a/scripts.go
+++ b/scripts.go
@@ -219,28 +219,6 @@ for (let i = 0; i < allWindows.length; i++) {
 
 `
 
-var JS_PREVIOUS_WINDOW string = `debugLog(scriptName + " executing JS_PREVIOUS_WINDOW");
-
-const allWindows = workspace.windowList();
-const windowStack = [];
-for (let i = 0; i < workspace.stackingOrder.length; i++) {
-    let w = workspace.stackingOrder[i];
-    if (w.resourceClass == 'plasmashell' || 
-        w.resourceClass == 'xwaylandvideobridge' ||
-        !allWindows.includes(w)) {
-        continue;
-    }
-    windowStack.push(w);
-}
-
-if (windowStack.length < 2) {
-    returnError("No previous window available");
-} else {
-    workspace.activeWindow = windowStack[windowStack.length - 2];
-}
-
-`
-
 var JS_MOUSE_POS string = `debugLog(scriptName + " executing JS_MOUSE_POS");
 
 const x = workspace.cursorPos.x;

--- a/usage.html
+++ b/usage.html
@@ -314,15 +314,6 @@ command (x y width height).
 </blockquote>
 </blockquote>
 
-<blockquote><b>previous-window</b>
-</blockquote>
-
-<blockquote>
-<blockquote>Switch to the second most recently active window. This command can be used
-to quickly switch between two windows.
-</blockquote>
-</blockquote>
-
 <blockquote><b>set-window-size</b> &lt;uuid&gt; &lt;width&gt; &lt;height&gt;
 </blockquote>
 


### PR DESCRIPTION
The `previous-window` command is now removed in favour of an optional installable KWin script that keeps track of window activation history and correctly switches to the previously active window.

Fixes #36