### PR TITLE
Add commands for getting and setting window opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ Here is the list of things that you can currently do with **kwst**:
 - Close a window.
 - Get window geometry (size and position).
 - Get window opacity.
-- Set window opacity.
-- Increase window opacity by 0.05, up to 1.0.
-- Decrease window opacity by 0.05, down to 0.1.
+- Change window opacity by setting it directly or using increase/decrease commands.
 - Set window geometry (size and position).
 - Set window properties (such as keepAbove, keepBelow, fullScreen, etc.)
 - Get the number of the active workspace.
@@ -56,8 +54,6 @@ kwst get-window-geometry "$window_id"
 kwst set-window-geometry "$window_id" 100 100 1200 800
 kwst get-window-opacity "$window_id"
 kwst set-window-opacity "$window_id" 0.8
-kwst increase-window-opacity "$window_id"
-kwst decrease-window-opacity "$window_id"
 ```
 
 Toggle the active window's always-on-top state:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Here is the list of things that you can currently do with **kwst**:
 - Activate a window.
 - Close a window.
 - Get window geometry (size and position).
+- Get window opacity.
+- Set window opacity.
+- Increase window opacity by 0.05, up to 1.0.
+- Decrease window opacity by 0.05, down to 0.1.
 - Set window geometry (size and position).
 - Set window properties (such as keepAbove, keepBelow, fullScreen, etc.)
 - Get the number of the active workspace.
@@ -44,12 +48,16 @@ List regular windows, including their captions:
 kwst list --show-captions
 ```
 
-Get the active window and inspect or change its geometry:
+Get the active window and inspect or change its geometry or opacity:
 
 ```sh
 window_id=$(kwst get-active-window)
 kwst get-window-geometry "$window_id"
 kwst set-window-geometry "$window_id" 100 100 1200 800
+kwst get-window-opacity "$window_id"
+kwst set-window-opacity "$window_id" 0.8
+kwst increase-window-opacity "$window_id"
+kwst decrease-window-opacity "$window_id"
 ```
 
 Toggle the active window's always-on-top state:

--- a/commands.go
+++ b/commands.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"math"
 	"os"
 )
 
@@ -231,5 +233,57 @@ func (gogc GetOutputGeometryCmd) Run(sp *ScriptPackage) error {
 	sp.ScriptTemplate += JS_GET_OUTPUT_GEOMETRY
 	sp.Params.ClientArea = gogc.ClientArea
 	sp.Params.OutputName = gogc.OutputName
+	return nil
+}
+
+type GetWindowOpacityCmd struct {
+	Uuid string `arg:"" required:"" help:"UUID of the window to get the opacity of."`
+}
+
+func (gwoc GetWindowOpacityCmd) Run(sp *ScriptPackage) error {
+	sp.ScriptTemplate += JS_GET_WINDOW_OPACITY
+	sp.Params.Uuid = gwoc.Uuid
+	return nil
+}
+
+type SetWindowOpacityCmd struct {
+	Uuid    string  `arg:"" required:"" help:"UUID of the window to change the opacity of."`
+	Opacity float64 `arg:"" required:"" help:"Opacity from 0.1 to 1.0 (inclusive)."`
+}
+
+func (swoc SetWindowOpacityCmd) Validate() error {
+	if math.IsNaN(swoc.Opacity) ||
+		math.IsInf(swoc.Opacity, 0) ||
+		swoc.Opacity < 0.1 ||
+		swoc.Opacity > 1.0 {
+		return fmt.Errorf("opacity must be between 0.1 and 1.0")
+	}
+	return nil
+}
+
+func (swoc SetWindowOpacityCmd) Run(sp *ScriptPackage) error {
+	sp.ScriptTemplate += JS_SET_WINDOW_OPACITY
+	sp.Params.Opacity = swoc.Opacity
+	sp.Params.Uuid = swoc.Uuid
+	return nil
+}
+
+type IncreaseWindowOpacityCmd struct {
+	Uuid string `arg:"" required:"" help:"UUID of the window to increase the opacity of."`
+}
+
+func (iwoc IncreaseWindowOpacityCmd) Run(sp *ScriptPackage) error {
+	sp.ScriptTemplate += JS_INCREASE_WINDOW_OPACITY
+	sp.Params.Uuid = iwoc.Uuid
+	return nil
+}
+
+type DecreaseWindowOpacityCmd struct {
+	Uuid string `arg:"" required:"" help:"UUID of the window to decrease the opacity of."`
+}
+
+func (dwoc DecreaseWindowOpacityCmd) Run(sp *ScriptPackage) error {
+	sp.ScriptTemplate += JS_DECREASE_WINDOW_OPACITY
+	sp.Params.Uuid = dwoc.Uuid
 	return nil
 }

--- a/integration/live_test.go
+++ b/integration/live_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -118,6 +119,10 @@ func TestKWinWorkflow(t *testing.T) {
 			{name: "set-window-workspace", arguments: []string{"set-window-workspace", missingUUID, "1"}},
 			{name: "set-window-property", arguments: []string{"set-window-property", "--property=keepAbove", "--value=true", missingUUID}},
 			{name: "close-window", arguments: []string{"close-window", missingUUID}},
+			{name: "get-window-opacity", arguments: []string{"get-window-opacity", missingUUID}},
+			{name: "set-window-opacity", arguments: []string{"set-window-opacity", missingUUID, "0.5"}},
+			{name: "increase-window-opacity", arguments: []string{"increase-window-opacity", missingUUID}},
+			{name: "decrease-window-opacity", arguments: []string{"decrease-window-opacity", missingUUID}},
 		}
 
 		for _, test := range tests {
@@ -146,6 +151,9 @@ func TestKWinWorkflow(t *testing.T) {
 	activateAndVerify(t, kwst, second)
 
 	testOutputCommands(t, kwst)
+	t.Run("window opacity commands", func(t *testing.T) {
+		testWindowOpacityCommands(t, kwst, first)
+	})
 
 	resizeAndMoveFixture(t, kwst, first)
 
@@ -505,6 +513,82 @@ func testOutputCommands(t *testing.T, kwst string) {
 	}
 }
 
+func testWindowOpacityCommands(t *testing.T, kwst string, fixture *fixtureWindow) {
+	t.Helper()
+
+	original := getOpacity(t, kwst, fixture.uuid)
+	if math.IsNaN(original) || math.IsInf(original, 0) || original < 0.0 || original > 1.0 {
+		t.Fatalf("get-window-opacity returned %g, want a value between 0.0 and 1.0", original)
+	}
+	if original < 0.1 {
+		t.Fatalf("fixture opacity %g cannot be restored with set-window-opacity", original)
+	}
+	t.Cleanup(func() {
+		setOpacityAndWait(t, kwst, fixture.uuid, original)
+	})
+
+	t.Run("set rejects invalid values", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			arguments []string
+		}{
+			{name: "missing value", arguments: []string{"set-window-opacity", fixture.uuid}},
+			{name: "not a number", arguments: []string{"set-window-opacity", fixture.uuid, "not-a-number"}},
+			{name: "zero", arguments: []string{"set-window-opacity", fixture.uuid, "0.0"}},
+			{name: "below minimum", arguments: []string{"set-window-opacity", fixture.uuid, "0.099"}},
+			{name: "negative", arguments: []string{"set-window-opacity", fixture.uuid, "-0.5"}},
+			{name: "above maximum", arguments: []string{"set-window-opacity", fixture.uuid, "1.001"}},
+			{name: "NaN", arguments: []string{"set-window-opacity", fixture.uuid, "NaN"}},
+			{name: "positive infinity", arguments: []string{"set-window-opacity", fixture.uuid, "+Inf"}},
+			{name: "negative infinity", arguments: []string{"set-window-opacity", fixture.uuid, "-Inf"}},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				result := runKWST(t, kwst, test.arguments...)
+				if result.exitCode == 0 {
+					t.Fatalf("set-window-opacity accepted invalid input:\n%s", result.String())
+				}
+				if actual := getOpacity(t, kwst, fixture.uuid); !opacityEqual(actual, original) {
+					t.Fatalf("invalid input changed opacity to %g, want %g", actual, original)
+				}
+			})
+		}
+	})
+
+	t.Run("set changes opacity", func(t *testing.T) {
+		target := 0.5
+		if opacityEqual(original, target) {
+			target = 0.6
+		}
+		setOpacityAndWait(t, kwst, fixture.uuid, target)
+		actual := getOpacity(t, kwst, fixture.uuid)
+		if opacityEqual(original, actual) {
+			t.Fatalf("set-window-opacity did not change opacity from %g", original)
+		}
+	})
+
+	t.Run("increase and decrease change opacity", func(t *testing.T) {
+		setOpacityAndWait(t, kwst, fixture.uuid, 0.5)
+
+		requireSuccess(t, runKWST(t, kwst, "increase-window-opacity", fixture.uuid), "increase window opacity")
+		waitForOpacity(t, kwst, fixture.uuid, 0.55)
+
+		requireSuccess(t, runKWST(t, kwst, "decrease-window-opacity", fixture.uuid), "decrease window opacity")
+		waitForOpacity(t, kwst, fixture.uuid, 0.5)
+	})
+
+	t.Run("increase and decrease respect limits", func(t *testing.T) {
+		setOpacityAndWait(t, kwst, fixture.uuid, 1.0)
+		requireSuccess(t, runKWST(t, kwst, "increase-window-opacity", fixture.uuid), "increase opacity at upper limit")
+		waitForOpacity(t, kwst, fixture.uuid, 1.0)
+
+		setOpacityAndWait(t, kwst, fixture.uuid, 0.1)
+		requireSuccess(t, runKWST(t, kwst, "decrease-window-opacity", fixture.uuid), "decrease opacity at lower limit")
+		waitForOpacity(t, kwst, fixture.uuid, 0.1)
+	})
+}
+
 func resizeAndMoveFixture(t *testing.T, kwst string, fixture *fixtureWindow) {
 	t.Helper()
 
@@ -548,6 +632,49 @@ func getGeometry(t *testing.T, kwst, uuid string) geometry {
 		t.Fatalf("parse fixture geometry %q: %v", result.stdout, err)
 	}
 	return value
+}
+
+func getOpacity(t *testing.T, kwst, uuid string) float64 {
+	t.Helper()
+	opacity, result := readOpacity(t, kwst, uuid)
+	requireSuccess(t, result, "get window opacity")
+	return opacity
+}
+
+func readOpacity(t *testing.T, kwst, uuid string) (float64, commandResult) {
+	t.Helper()
+	result := runKWST(t, kwst, "get-window-opacity", uuid)
+	if result.exitCode != 0 {
+		return 0, result
+	}
+	opacity, err := strconv.ParseFloat(result.stdout, 64)
+	if err != nil {
+		result.exitCode = -1
+		result.stderr = fmt.Sprintf("parse window opacity %q: %v", result.stdout, err)
+	}
+	return opacity, result
+}
+
+func setOpacityAndWait(t *testing.T, kwst, uuid string, opacity float64) {
+	t.Helper()
+	value := strconv.FormatFloat(opacity, 'f', -1, 64)
+	requireSuccess(t, runKWST(t, kwst, "set-window-opacity", uuid, value), "set window opacity")
+	waitForOpacity(t, kwst, uuid, opacity)
+}
+
+func waitForOpacity(t *testing.T, kwst, uuid string, expected float64) {
+	t.Helper()
+	eventually(t, fmt.Sprintf("window opacity to become %g", expected), func() (bool, string) {
+		actual, result := readOpacity(t, kwst, uuid)
+		if result.exitCode != 0 {
+			return false, result.String()
+		}
+		return opacityEqual(actual, expected), fmt.Sprintf("got %g, want %g", actual, expected)
+	})
+}
+
+func opacityEqual(left, right float64) bool {
+	return math.Abs(left-right) < 1e-9
 }
 
 func parseGeometry(value string) (geometry, error) {

--- a/kwst.1.scd
+++ b/kwst.1.scd
@@ -106,6 +106,22 @@ script to finish returns status 124.
 		The data is returned in the format required for the set-window-geometry
 		command (x y width height).
 
+	*get-window-opacity* <uuid>
+		Get the opacity of the window with the specified UUID. The returned value
+		ranges from 0.0 (fully transparent) to 1.0 (fully opaque).
+
+	*set-window-opacity* <uuid> <opacity>
+		Set the opacity of the window with the specified UUID. The opacity must be
+		between 0.1 and 1.0, inclusive.
+
+	*increase-window-opacity* <uuid>
+		Increase the opacity of the window with the specified UUID by 0.05. The
+		opacity cannot be increased above 1.0.
+
+	*decrease-window-opacity* <uuid>
+		Decrease the opacity of the window with the specified UUID by 0.05. The
+		opacity cannot be decreased below 0.1.
+
 	*get-workspace*
 		Get the ID of the active workspace.
 

--- a/main.go
+++ b/main.go
@@ -49,6 +49,10 @@ type CLI struct {
 	GetCursorOutput       GetCursorOutputCmd       `cmd:"" help:"Return the output containing the mouse cursor."`
 	GetActiveWindowOutput GetActiveWindowOutputCmd `cmd:"" help:"Return the output containing the geometric centre of the active window."`
 	GetOutputGeometry     GetOutputGeometryCmd     `cmd:"" help:"Return the geometry (size and position) of the specified output. The data is returned in the following format: x y width height."`
+	GetWindowOpacity      GetWindowOpacityCmd      `cmd:"" help:"Return the opacity of the specified window (from 0.0 to 1.0)."`
+	SetWindowOpacity      SetWindowOpacityCmd      `cmd:"" help:"Set the opacity of the window with the provided UUID, if such a window exists."`
+	IncreaseWindowOpacity IncreaseWindowOpacityCmd `cmd:"" help:"Increase the opacity of the window with the provided UUID by 0.05. Opacity can't be set higher than 1.0."`
+	DecreaseWindowOpacity DecreaseWindowOpacityCmd `cmd:"" help:"Decrease the opacity of the window with the provided UUID by 0.05. Opacity can't be set lower than 0.1."`
 }
 
 // parameters that are passed to the script template
@@ -77,6 +81,7 @@ type ScriptParams struct {
 	P6                    string
 	ClientArea            bool
 	OutputName            string
+	Opacity               float64
 }
 
 type ScriptPackage struct {

--- a/main_test.go
+++ b/main_test.go
@@ -179,6 +179,30 @@ func TestCommandRunMethods(t *testing.T) {
 			wantTemplate: initialTemplate + JS_GET_OUTPUT_GEOMETRY,
 			wantParams:   ScriptParams{ClientArea: true, OutputName: "DP-1"},
 		},
+		{
+			name:         "get window opacity",
+			command:      &GetWindowOpacityCmd{Uuid: "window-id"},
+			wantTemplate: initialTemplate + JS_GET_WINDOW_OPACITY,
+			wantParams:   ScriptParams{Uuid: "window-id"},
+		},
+		{
+			name:         "set window opacity",
+			command:      &SetWindowOpacityCmd{Uuid: "window-id", Opacity: 0.5},
+			wantTemplate: initialTemplate + JS_SET_WINDOW_OPACITY,
+			wantParams:   ScriptParams{Uuid: "window-id", Opacity: 0.5},
+		},
+		{
+			name:         "increase window opacity",
+			command:      &IncreaseWindowOpacityCmd{Uuid: "window-id"},
+			wantTemplate: initialTemplate + JS_INCREASE_WINDOW_OPACITY,
+			wantParams:   ScriptParams{Uuid: "window-id"},
+		},
+		{
+			name:         "decrease window opacity",
+			command:      &DecreaseWindowOpacityCmd{Uuid: "window-id"},
+			wantTemplate: initialTemplate + JS_DECREASE_WINDOW_OPACITY,
+			wantParams:   ScriptParams{Uuid: "window-id"},
+		},
 	}
 
 	for _, test := range tests {

--- a/scripts.go
+++ b/scripts.go
@@ -301,6 +301,71 @@ if (!output) {
 
 `
 
+var JS_GET_WINDOW_OPACITY string = `debugLog(scriptName + " executing JS_GET_WINDOW_OPACITY");
+
+const targetWindow = workspace.windowList().find(
+    (window) => window.internalId == {{jsString .Uuid}}
+);
+if (!targetWindow) {
+    returnError("Window not found: " + {{jsString .Uuid}});
+} else {
+    returnResult(targetWindow.opacity);
+}
+
+`
+
+var JS_SET_WINDOW_OPACITY string = `debugLog(scriptName + " executing JS_SET_WINDOW_OPACITY");
+
+const targetWindow = workspace.windowList().find(
+    (window) => window.internalId == {{jsString .Uuid}}
+);
+if (!targetWindow) {
+    returnError("Window not found: " + {{jsString .Uuid}});
+} else {
+    debugLog("Setting opacity of window with UUID=" + {{jsString .Uuid}} + " to {{.Opacity}}");
+    targetWindow.opacity = {{.Opacity}};
+}
+
+`
+
+var JS_INCREASE_WINDOW_OPACITY string = `debugLog(scriptName + " executing JS_INCREASE_WINDOW_OPACITY");
+
+const targetWindow = workspace.windowList().find(
+    (window) => window.internalId == {{jsString .Uuid}}
+);
+if (!targetWindow) {
+    returnError("Window not found: " + {{jsString .Uuid}});
+} else {
+    let newOpacity = targetWindow.opacity;
+    newOpacity += 0.05;
+    if (newOpacity > 1.0) {
+        newOpacity = 1.0;
+    }
+    debugLog("Setting opacity of window with UUID=" + {{jsString .Uuid}} + " to " + newOpacity);
+    targetWindow.opacity = newOpacity;
+}
+
+`
+
+var JS_DECREASE_WINDOW_OPACITY string = `debugLog(scriptName + " executing JS_DECREASE_WINDOW_OPACITY");
+
+const targetWindow = workspace.windowList().find(
+    (window) => window.internalId == {{jsString .Uuid}}
+);
+if (!targetWindow) {
+    returnError("Window not found: " + {{jsString .Uuid}});
+} else {
+    let newOpacity = targetWindow.opacity;
+    newOpacity -= 0.05;
+    if (newOpacity < 0.1) {
+        newOpacity = 0.1;
+    }
+    debugLog("Setting opacity of window with UUID=" + {{jsString .Uuid}} + " to " + newOpacity);
+    targetWindow.opacity = newOpacity;
+}
+
+`
+
 var JS_FOOTER string = `close();
 debugLog(scriptName + " END");
 `

--- a/usage.html
+++ b/usage.html
@@ -134,7 +134,7 @@
 <body>
 <header>
 <h1>KWST(1)</h1>
-<p class="header-date">2026-07-30</p>
+<p class="header-date">2026-07-31</p>
 </header>
 <section>
 <h2 id="NAME">NAME <a aria-hidden="true" href="#NAME">¶</a></h2>
@@ -345,6 +345,42 @@ example:
 <blockquote>Get the geometry (size and position) of the window with the specified UUID.
 The data is returned in the format required for the set-window-geometry
 command (x y width height).
+</blockquote>
+</blockquote>
+
+<blockquote><b>get-window-opacity</b> &lt;uuid&gt;
+</blockquote>
+
+<blockquote>
+<blockquote>Get the opacity of the window with the specified UUID. The returned value
+ranges from 0.0 (fully transparent) to 1.0 (fully opaque).
+</blockquote>
+</blockquote>
+
+<blockquote><b>set-window-opacity</b> &lt;uuid&gt; &lt;opacity&gt;
+</blockquote>
+
+<blockquote>
+<blockquote>Set the opacity of the window with the specified UUID. The opacity must be
+between 0.1 and 1.0, inclusive.
+</blockquote>
+</blockquote>
+
+<blockquote><b>increase-window-opacity</b> &lt;uuid&gt;
+</blockquote>
+
+<blockquote>
+<blockquote>Increase the opacity of the window with the specified UUID by 0.05. The
+opacity cannot be increased above 1.0.
+</blockquote>
+</blockquote>
+
+<blockquote><b>decrease-window-opacity</b> &lt;uuid&gt;
+</blockquote>
+
+<blockquote>
+<blockquote>Decrease the opacity of the window with the specified UUID by 0.05. The
+opacity cannot be decreased below 0.1.
 </blockquote>
 </blockquote>
 


### PR DESCRIPTION
This change implements the following new commands:

- `get-window-opacity`;
- `set-window-opacity`;
- `increase-window-opacity`;
- `decrease-window-opacity`.

It also adds corresponding unit tests and live integration tests, as well as updates to the documentation.

Closes #46 
