### PR TITLE
Feature/48 relative geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Here is the list of things that you can currently do with **kwst**:
 - Get window opacity.
 - Change window opacity by setting it directly or using increase/decrease commands.
 - Set window geometry (size and position).
+- Set window geometry relative to the client area of its output.
 - Set window properties (such as keepAbove, keepBelow, fullScreen, etc.)
 - Get the number of the active workspace.
 - Switch to a workspace.
@@ -52,6 +53,7 @@ Get the active window and inspect or change its geometry or opacity:
 window_id=$(kwst get-active-window)
 kwst get-window-geometry "$window_id"
 kwst set-window-geometry "$window_id" 100 100 1200 800
+kwst set-window-geometry-relative "$window_id" 0 0 50 100
 kwst get-window-opacity "$window_id"
 kwst set-window-opacity "$window_id" 0.8
 ```

--- a/commands.go
+++ b/commands.go
@@ -6,6 +6,11 @@ import (
 	"os"
 )
 
+const (
+	minRelativeSizePercent = 10
+	maxRelativePercent     = 100
+)
+
 type ListCmd struct {
 	IncludeSpecialWindows bool `default:"false" short:"s" help:"Include special windows that are not meant to be manipulated, e.g. plasmashell panels, desktop, etc. Such windows are not listed by default."`
 	ShowCaptions          bool `default:"false" short:"c" help:"Show window captions in the list."`
@@ -310,26 +315,26 @@ func (cmd *SetWindowGeometryRelativeCmd) Validate() error {
 	if cmd.RelativeX < 0 {
 		cmd.RelativeX = 0
 	}
-	if cmd.RelativeX > 100 {
-		cmd.RelativeX = 100
+	if cmd.RelativeX > maxRelativePercent {
+		cmd.RelativeX = maxRelativePercent
 	}
 	if cmd.RelativeY < 0 {
 		cmd.RelativeY = 0
 	}
-	if cmd.RelativeY > 100 {
-		cmd.RelativeY = 100
+	if cmd.RelativeY > maxRelativePercent {
+		cmd.RelativeY = maxRelativePercent
 	}
-	if cmd.RelativeWidth < 10 {
-		cmd.RelativeWidth = 10
+	if cmd.RelativeWidth < minRelativeSizePercent {
+		cmd.RelativeWidth = minRelativeSizePercent
 	}
-	if cmd.RelativeWidth > 100 {
-		cmd.RelativeWidth = 100
+	if cmd.RelativeWidth > maxRelativePercent {
+		cmd.RelativeWidth = maxRelativePercent
 	}
-	if cmd.RelativeHeight < 10 {
-		cmd.RelativeHeight = 10
+	if cmd.RelativeHeight < minRelativeSizePercent {
+		cmd.RelativeHeight = minRelativeSizePercent
 	}
-	if cmd.RelativeHeight > 100 {
-		cmd.RelativeHeight = 100
+	if cmd.RelativeHeight > maxRelativePercent {
+		cmd.RelativeHeight = maxRelativePercent
 	}
 	return nil
 }
@@ -341,5 +346,77 @@ func (cmd SetWindowGeometryRelativeCmd) Run(sp *ScriptPackage) error {
 	sp.Params.RelativeY = cmd.RelativeY
 	sp.Params.RelativeWidth = cmd.RelativeWidth
 	sp.Params.RelativeHeight = cmd.RelativeHeight
+	return nil
+}
+
+type SetWindowSizeRelativeCmd struct {
+	Uuid           string  `arg:"" required:"" help:"UUID of the window to change the size of."`
+	RelativeWidth  float64 `arg:"" required:""`
+	RelativeHeight float64 `arg:"" required:""`
+}
+
+func (cmd *SetWindowSizeRelativeCmd) Validate() error {
+	if math.IsNaN(cmd.RelativeWidth) ||
+		math.IsNaN(cmd.RelativeHeight) ||
+		math.IsInf(cmd.RelativeWidth, 0) ||
+		math.IsInf(cmd.RelativeHeight, 0) {
+		return fmt.Errorf("relative width and height must be valid numbers")
+	}
+	if cmd.RelativeWidth < minRelativeSizePercent {
+		cmd.RelativeWidth = minRelativeSizePercent
+	}
+	if cmd.RelativeWidth > maxRelativePercent {
+		cmd.RelativeWidth = maxRelativePercent
+	}
+	if cmd.RelativeHeight < minRelativeSizePercent {
+		cmd.RelativeHeight = minRelativeSizePercent
+	}
+	if cmd.RelativeHeight > maxRelativePercent {
+		cmd.RelativeHeight = maxRelativePercent
+	}
+	return nil
+}
+
+func (cmd SetWindowSizeRelativeCmd) Run(sp *ScriptPackage) error {
+	sp.ScriptTemplate += JS_SET_WINDOW_SIZE_RELATIVE
+	sp.Params.Uuid = cmd.Uuid
+	sp.Params.RelativeWidth = cmd.RelativeWidth
+	sp.Params.RelativeHeight = cmd.RelativeHeight
+	return nil
+}
+
+type SetWindowPositionRelativeCmd struct {
+	Uuid      string  `arg:"" required:"" help:"UUID of the window to change the geometry of."`
+	RelativeX float64 `arg:"" required:""`
+	RelativeY float64 `arg:"" required:""`
+}
+
+func (cmd *SetWindowPositionRelativeCmd) Validate() error {
+	if math.IsNaN(cmd.RelativeX) ||
+		math.IsNaN(cmd.RelativeY) ||
+		math.IsInf(cmd.RelativeX, 0) ||
+		math.IsInf(cmd.RelativeY, 0) {
+		return fmt.Errorf("relative X and Y must be valid numbers")
+	}
+	if cmd.RelativeX < 0 {
+		cmd.RelativeX = 0
+	}
+	if cmd.RelativeX > maxRelativePercent {
+		cmd.RelativeX = maxRelativePercent
+	}
+	if cmd.RelativeY < 0 {
+		cmd.RelativeY = 0
+	}
+	if cmd.RelativeY > maxRelativePercent {
+		cmd.RelativeY = maxRelativePercent
+	}
+	return nil
+}
+
+func (cmd SetWindowPositionRelativeCmd) Run(sp *ScriptPackage) error {
+	sp.ScriptTemplate += JS_SET_WINDOW_POSITION_RELATIVE
+	sp.Params.Uuid = cmd.Uuid
+	sp.Params.RelativeX = cmd.RelativeX
+	sp.Params.RelativeY = cmd.RelativeY
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -312,30 +312,10 @@ func (cmd *SetWindowGeometryRelativeCmd) Validate() error {
 		math.IsInf(cmd.RelativeHeight, 0) {
 		return fmt.Errorf("relative X, Y, width and height must be valid numbers")
 	}
-	if cmd.RelativeX < 0 {
-		cmd.RelativeX = 0
-	}
-	if cmd.RelativeX > maxRelativePercent {
-		cmd.RelativeX = maxRelativePercent
-	}
-	if cmd.RelativeY < 0 {
-		cmd.RelativeY = 0
-	}
-	if cmd.RelativeY > maxRelativePercent {
-		cmd.RelativeY = maxRelativePercent
-	}
-	if cmd.RelativeWidth < minRelativeSizePercent {
-		cmd.RelativeWidth = minRelativeSizePercent
-	}
-	if cmd.RelativeWidth > maxRelativePercent {
-		cmd.RelativeWidth = maxRelativePercent
-	}
-	if cmd.RelativeHeight < minRelativeSizePercent {
-		cmd.RelativeHeight = minRelativeSizePercent
-	}
-	if cmd.RelativeHeight > maxRelativePercent {
-		cmd.RelativeHeight = maxRelativePercent
-	}
+	cmd.RelativeX = min(max(cmd.RelativeX, 0), maxRelativePercent)
+	cmd.RelativeY = min(max(cmd.RelativeY, 0), maxRelativePercent)
+	cmd.RelativeWidth = min(max(cmd.RelativeWidth, minRelativeSizePercent), maxRelativePercent)
+	cmd.RelativeHeight = min(max(cmd.RelativeHeight, minRelativeSizePercent), maxRelativePercent)
 	return nil
 }
 
@@ -362,18 +342,8 @@ func (cmd *SetWindowSizeRelativeCmd) Validate() error {
 		math.IsInf(cmd.RelativeHeight, 0) {
 		return fmt.Errorf("relative width and height must be valid numbers")
 	}
-	if cmd.RelativeWidth < minRelativeSizePercent {
-		cmd.RelativeWidth = minRelativeSizePercent
-	}
-	if cmd.RelativeWidth > maxRelativePercent {
-		cmd.RelativeWidth = maxRelativePercent
-	}
-	if cmd.RelativeHeight < minRelativeSizePercent {
-		cmd.RelativeHeight = minRelativeSizePercent
-	}
-	if cmd.RelativeHeight > maxRelativePercent {
-		cmd.RelativeHeight = maxRelativePercent
-	}
+	cmd.RelativeWidth = min(max(cmd.RelativeWidth, minRelativeSizePercent), maxRelativePercent)
+	cmd.RelativeHeight = min(max(cmd.RelativeHeight, minRelativeSizePercent), maxRelativePercent)
 	return nil
 }
 
@@ -398,18 +368,8 @@ func (cmd *SetWindowPositionRelativeCmd) Validate() error {
 		math.IsInf(cmd.RelativeY, 0) {
 		return fmt.Errorf("relative X and Y must be valid numbers")
 	}
-	if cmd.RelativeX < 0 {
-		cmd.RelativeX = 0
-	}
-	if cmd.RelativeX > maxRelativePercent {
-		cmd.RelativeX = maxRelativePercent
-	}
-	if cmd.RelativeY < 0 {
-		cmd.RelativeY = 0
-	}
-	if cmd.RelativeY > maxRelativePercent {
-		cmd.RelativeY = maxRelativePercent
-	}
+	cmd.RelativeX = min(max(cmd.RelativeX, 0), maxRelativePercent)
+	cmd.RelativeY = min(max(cmd.RelativeY, 0), maxRelativePercent)
 	return nil
 }
 

--- a/commands.go
+++ b/commands.go
@@ -287,3 +287,59 @@ func (dwoc DecreaseWindowOpacityCmd) Run(sp *ScriptPackage) error {
 	sp.Params.Uuid = dwoc.Uuid
 	return nil
 }
+
+type SetWindowGeometryRelativeCmd struct {
+	Uuid           string  `arg:"" required:"" help:"UUID of the window to change the geometry of."`
+	RelativeX      float64 `arg:"" required:""`
+	RelativeY      float64 `arg:"" required:""`
+	RelativeWidth  float64 `arg:"" required:""`
+	RelativeHeight float64 `arg:"" required:""`
+}
+
+func (cmd *SetWindowGeometryRelativeCmd) Validate() error {
+	if math.IsNaN(cmd.RelativeX) ||
+		math.IsNaN(cmd.RelativeY) ||
+		math.IsNaN(cmd.RelativeWidth) ||
+		math.IsNaN(cmd.RelativeHeight) ||
+		math.IsInf(cmd.RelativeX, 0) ||
+		math.IsInf(cmd.RelativeY, 0) ||
+		math.IsInf(cmd.RelativeWidth, 0) ||
+		math.IsInf(cmd.RelativeHeight, 0) {
+		return fmt.Errorf("relative X, Y, width and height must be valid numbers")
+	}
+	if cmd.RelativeX < 0 {
+		cmd.RelativeX = 0
+	}
+	if cmd.RelativeX > 100 {
+		cmd.RelativeX = 100
+	}
+	if cmd.RelativeY < 0 {
+		cmd.RelativeY = 0
+	}
+	if cmd.RelativeY > 100 {
+		cmd.RelativeY = 100
+	}
+	if cmd.RelativeWidth < 10 {
+		cmd.RelativeWidth = 10
+	}
+	if cmd.RelativeWidth > 100 {
+		cmd.RelativeWidth = 100
+	}
+	if cmd.RelativeHeight < 10 {
+		cmd.RelativeHeight = 10
+	}
+	if cmd.RelativeHeight > 100 {
+		cmd.RelativeHeight = 100
+	}
+	return nil
+}
+
+func (cmd SetWindowGeometryRelativeCmd) Run(sp *ScriptPackage) error {
+	sp.ScriptTemplate += JS_SET_WINDOW_GEOMETRY_RELATIVE
+	sp.Params.Uuid = cmd.Uuid
+	sp.Params.RelativeX = cmd.RelativeX
+	sp.Params.RelativeY = cmd.RelativeY
+	sp.Params.RelativeWidth = cmd.RelativeWidth
+	sp.Params.RelativeHeight = cmd.RelativeHeight
+	return nil
+}

--- a/integration/live_test.go
+++ b/integration/live_test.go
@@ -116,6 +116,9 @@ func TestKWinWorkflow(t *testing.T) {
 			{name: "set-window-size", arguments: []string{"set-window-size", missingUUID, "640", "480"}},
 			{name: "set-window-position", arguments: []string{"set-window-position", missingUUID, "10", "20"}},
 			{name: "set-window-geometry", arguments: []string{"set-window-geometry", missingUUID, "10", "20", "640", "480"}},
+			{name: "set-window-geometry-relative", arguments: []string{"set-window-geometry-relative", missingUUID, "10", "20", "50", "50"}},
+			{name: "set-window-size-relative", arguments: []string{"set-window-size-relative", missingUUID, "50", "50"}},
+			{name: "set-window-position-relative", arguments: []string{"set-window-position-relative", missingUUID, "10", "20"}},
 			{name: "set-window-workspace", arguments: []string{"set-window-workspace", missingUUID, "1"}},
 			{name: "set-window-property", arguments: []string{"set-window-property", "--property=keepAbove", "--value=true", missingUUID}},
 			{name: "close-window", arguments: []string{"close-window", missingUUID}},
@@ -153,6 +156,9 @@ func TestKWinWorkflow(t *testing.T) {
 	testOutputCommands(t, kwst)
 	t.Run("window opacity commands", func(t *testing.T) {
 		testWindowOpacityCommands(t, kwst, first)
+	})
+	t.Run("relative geometry commands", func(t *testing.T) {
+		testRelativeGeometryCommands(t, kwst, first)
 	})
 
 	resizeAndMoveFixture(t, kwst, first)
@@ -589,6 +595,151 @@ func testWindowOpacityCommands(t *testing.T, kwst string, fixture *fixtureWindow
 	})
 }
 
+func testRelativeGeometryCommands(t *testing.T, kwst string, fixture *fixtureWindow) {
+	t.Helper()
+
+	activateAndVerify(t, kwst, fixture)
+	outputResult := runKWST(t, kwst, "get-active-window-output")
+	outputName := requireSingleOutputName(t, outputResult, "get fixture output")
+	areaResult := runKWST(t, kwst, "get-output-geometry", "--client-area", outputName)
+	requireSuccess(t, areaResult, "get fixture output client area")
+	clientArea, err := parseGeometry(areaResult.stdout)
+	if err != nil {
+		t.Fatalf("parse fixture output client area %q: %v", areaResult.stdout, err)
+	}
+	if clientArea.width <= 0 || clientArea.height <= 0 {
+		t.Fatalf("fixture output has non-positive client area dimensions: %+v", clientArea)
+	}
+
+	original := getGeometry(t, kwst, fixture.uuid)
+	t.Cleanup(func() {
+		setGeometryAndWait(t, kwst, fixture.uuid, original)
+	})
+
+	baseline := relativeGeometry(clientArea, 20, 20, 60, 60)
+
+	t.Run("set relative position", func(t *testing.T) {
+		setGeometryAndWait(t, kwst, fixture.uuid, baseline)
+		expected := baseline
+		expected.x = relativeCoordinate(clientArea.x, clientArea.width, 10)
+		expected.y = relativeCoordinate(clientArea.y, clientArea.height, 10)
+
+		requireSuccess(t, runKWST(t, kwst, "set-window-position-relative", fixture.uuid, "10", "10"), "set relative fixture position")
+		waitForGeometry(t, kwst, fixture.uuid, expected)
+	})
+
+	t.Run("set relative size", func(t *testing.T) {
+		setGeometryAndWait(t, kwst, fixture.uuid, baseline)
+		expected := baseline
+		expected.width = relativeLength(clientArea.width, 50)
+		expected.height = relativeLength(clientArea.height, 50)
+
+		requireSuccess(t, runKWST(t, kwst, "set-window-size-relative", fixture.uuid, "50", "50"), "set relative fixture size")
+		waitForGeometry(t, kwst, fixture.uuid, expected)
+	})
+
+	t.Run("set relative geometry", func(t *testing.T) {
+		setGeometryAndWait(t, kwst, fixture.uuid, baseline)
+		expected := relativeGeometry(clientArea, 10, 10, 50, 50)
+
+		requireSuccess(t, runKWST(t, kwst, "set-window-geometry-relative", fixture.uuid, "10", "10", "50", "50"), "set relative fixture geometry")
+		waitForGeometry(t, kwst, fixture.uuid, expected)
+	})
+
+	positionClampTests := []struct {
+		name         string
+		boundaryArgs []string
+		clampedArgs  []string
+	}{
+		{
+			name:         "geometry lower position limit",
+			boundaryArgs: []string{"set-window-geometry-relative", fixture.uuid, "0", "0", "50", "50"},
+			clampedArgs:  []string{"set-window-geometry-relative", "--", fixture.uuid, "-10", "-20", "50", "50"},
+		},
+		{
+			name:         "geometry upper position limit",
+			boundaryArgs: []string{"set-window-geometry-relative", fixture.uuid, "100", "100", "50", "50"},
+			clampedArgs:  []string{"set-window-geometry-relative", fixture.uuid, "110", "120", "50", "50"},
+		},
+		{
+			name:         "position lower limit",
+			boundaryArgs: []string{"set-window-position-relative", fixture.uuid, "0", "0"},
+			clampedArgs:  []string{"set-window-position-relative", "--", fixture.uuid, "-10", "-20"},
+		},
+		{
+			name:         "position upper limit",
+			boundaryArgs: []string{"set-window-position-relative", fixture.uuid, "100", "100"},
+			clampedArgs:  []string{"set-window-position-relative", fixture.uuid, "110", "120"},
+		},
+	}
+	for _, test := range positionClampTests {
+		t.Run("clamp "+test.name, func(t *testing.T) {
+			verifyRelativeClamp(t, kwst, fixture.uuid, baseline, test.boundaryArgs, test.clampedArgs)
+		})
+	}
+
+	dimensionClampTests := []struct {
+		name         string
+		boundaryArgs []string
+		clampedArgs  []string
+	}{
+		{
+			name:         "geometry lower dimension limit",
+			boundaryArgs: []string{"set-window-geometry-relative", fixture.uuid, "10", "10", "10", "10"},
+			clampedArgs:  []string{"set-window-geometry-relative", fixture.uuid, "10", "10", "0", "9"},
+		},
+		{
+			name:         "geometry upper dimension limit",
+			boundaryArgs: []string{"set-window-geometry-relative", fixture.uuid, "10", "10", "100", "100"},
+			clampedArgs:  []string{"set-window-geometry-relative", fixture.uuid, "10", "10", "110", "120"},
+		},
+		{
+			name:         "size lower limit",
+			boundaryArgs: []string{"set-window-size-relative", fixture.uuid, "10", "10"},
+			clampedArgs:  []string{"set-window-size-relative", fixture.uuid, "0", "9"},
+		},
+		{
+			name:         "size upper limit",
+			boundaryArgs: []string{"set-window-size-relative", fixture.uuid, "100", "100"},
+			clampedArgs:  []string{"set-window-size-relative", fixture.uuid, "110", "120"},
+		},
+	}
+	for _, test := range dimensionClampTests {
+		t.Run("clamp "+test.name, func(t *testing.T) {
+			verifyRelativeClamp(t, kwst, fixture.uuid, baseline, test.boundaryArgs, test.clampedArgs)
+		})
+	}
+}
+
+func relativeGeometry(area geometry, xPercent, yPercent, widthPercent, heightPercent float64) geometry {
+	return geometry{
+		x:      relativeCoordinate(area.x, area.width, xPercent),
+		y:      relativeCoordinate(area.y, area.height, yPercent),
+		width:  relativeLength(area.width, widthPercent),
+		height: relativeLength(area.height, heightPercent),
+	}
+}
+
+func relativeCoordinate(origin, length int, percent float64) int {
+	return origin + relativeLength(length, percent)
+}
+
+func relativeLength(length int, percent float64) int {
+	return int(math.Round(float64(length) * percent / 100))
+}
+
+func verifyRelativeClamp(t *testing.T, kwst, uuid string, baseline geometry, boundaryArgs, clampedArgs []string) {
+	t.Helper()
+
+	setGeometryAndWait(t, kwst, uuid, baseline)
+	requireSuccess(t, runKWST(t, kwst, boundaryArgs...), "set relative boundary value")
+	boundary := waitForGeometryChange(t, kwst, uuid, baseline)
+
+	setGeometryAndWait(t, kwst, uuid, baseline)
+	requireSuccess(t, runKWST(t, kwst, clampedArgs...), "set out-of-range relative value")
+	waitForGeometry(t, kwst, uuid, boundary)
+}
+
 func resizeAndMoveFixture(t *testing.T, kwst string, fixture *fixtureWindow) {
 	t.Helper()
 
@@ -632,6 +783,50 @@ func getGeometry(t *testing.T, kwst, uuid string) geometry {
 		t.Fatalf("parse fixture geometry %q: %v", result.stdout, err)
 	}
 	return value
+}
+
+func setGeometryAndWait(t *testing.T, kwst, uuid string, expected geometry) {
+	t.Helper()
+	requireSuccess(t, runKWST(t, kwst, "set-window-geometry", uuid,
+		strconv.Itoa(expected.x),
+		strconv.Itoa(expected.y),
+		strconv.Itoa(expected.width),
+		strconv.Itoa(expected.height),
+	), "set fixture geometry")
+	waitForGeometry(t, kwst, uuid, expected)
+}
+
+func waitForGeometry(t *testing.T, kwst, uuid string, expected geometry) {
+	t.Helper()
+	eventually(t, fmt.Sprintf("window geometry to become %+v", expected), func() (bool, string) {
+		result := runKWST(t, kwst, "get-window-geometry", uuid)
+		if result.exitCode != 0 {
+			return false, result.String()
+		}
+		actual, err := parseGeometry(result.stdout)
+		if err != nil {
+			return false, err.Error()
+		}
+		return actual == expected, fmt.Sprintf("got %+v, want %+v", actual, expected)
+	})
+}
+
+func waitForGeometryChange(t *testing.T, kwst, uuid string, original geometry) geometry {
+	t.Helper()
+	var actual geometry
+	eventually(t, fmt.Sprintf("window geometry to change from %+v", original), func() (bool, string) {
+		result := runKWST(t, kwst, "get-window-geometry", uuid)
+		if result.exitCode != 0 {
+			return false, result.String()
+		}
+		var err error
+		actual, err = parseGeometry(result.stdout)
+		if err != nil {
+			return false, err.Error()
+		}
+		return actual != original, fmt.Sprintf("geometry is still %+v", actual)
+	})
+	return actual
 }
 
 func getOpacity(t *testing.T, kwst, uuid string) float64 {
@@ -684,11 +879,11 @@ func parseGeometry(value string) (geometry, error) {
 	}
 	parts := make([]int, 4)
 	for index, field := range fields {
-		part, err := strconv.Atoi(field)
+		part, err := strconv.ParseFloat(field, 64)
 		if err != nil {
 			return geometry{}, fmt.Errorf("invalid geometry %q: %w", value, err)
 		}
-		parts[index] = part
+		parts[index] = int(math.Round(part))
 	}
 	return geometry{x: parts[0], y: parts[1], width: parts[2], height: parts[3]}, nil
 }

--- a/kwst.1.scd
+++ b/kwst.1.scd
@@ -42,6 +42,7 @@ Get the active window and inspect or change its geometry:
 	window_id=$(*kwst get-active-window*)
 	*kwst get-window-geometry "$window_id"*
 	*kwst set-window-geometry "$window_id" 100 100 1200 800*
+	*kwst set-window-geometry-relative "$window_id" 0 0 50 100*
 
 Toggle the active window's always-on-top state:
 
@@ -142,6 +143,12 @@ script to finish returns status 124.
 	*set-window-geometry* <uuid> <x> <y> <width> <height>
 		Change geometry of the window with the provided UUID, provided
 		that such a window exists.
+
+	*set-window-geometry-relative* <uuid> <relative-x> <relative-y> <relative-width> <relative-height>
+		Change the geometry of the window with the provided UUID using percentages
+		of the client area of the output containing the window. Relative X and Y are
+		clamped between 0 and 100 percent. Relative width and height are clamped
+		between 10 and 100 percent. Fractional percentages are accepted.
 
 	*set-window-workspace* <uuid> <workspace-id>
 		Send the window with the specified UUID to the workspace with the specified

--- a/kwst.1.scd
+++ b/kwst.1.scd
@@ -43,6 +43,8 @@ Get the active window and inspect or change its geometry:
 	*kwst get-window-geometry "$window_id"*
 	*kwst set-window-geometry "$window_id" 100 100 1200 800*
 	*kwst set-window-geometry-relative "$window_id" 0 0 50 100*
+	*kwst set-window-size-relative "$window_id" 50 100*
+	*kwst set-window-position-relative "$window_id" 25 25*
 
 Toggle the active window's always-on-top state:
 
@@ -136,9 +138,19 @@ script to finish returns status 124.
 		Set the size of the window with the provided UUID, provided that
 		such a window exists.		
 
+	*set-window-size-relative* <uuid> <relative-width> <relative-height>
+		Set the size of the window with the provided UUID using percentages of the
+		client area of the output containing the window. Relative width and height
+		are clamped between 10 and 100 percent. Fractional percentages are accepted.
+
 	*set-window-position* <uuid> <x> <y>
 		Set the position of the window with the provided UUID, provided
 		that such a window exists.
+
+	*set-window-position-relative* <uuid> <relative-x> <relative-y>
+		Set the position of the window with the provided UUID using percentages of
+		the client area of the output containing the window. Relative X and Y are
+		clamped between 0 and 100 percent. Fractional percentages are accepted.
 
 	*set-window-geometry* <uuid> <x> <y> <width> <height>
 		Change geometry of the window with the provided UUID, provided

--- a/main.go
+++ b/main.go
@@ -29,30 +29,31 @@ type Globals struct {
 type CLI struct {
 	Globals
 
-	List                  ListCmd                  `cmd:"" help:"List all windows. The data is returned as tab-separated rows containing the window's UUID, resourceClass and resourceName. Each window is represented by a separate row."`
-	Find                  FindCmd                  `cmd:"" help:"Search for windows using a case-insensitive regular expression."`
-	GetActiveWindow       GetActiveWindowCmd       `cmd:"" help:"Get the UUID of the active window."`
-	GetWindowGeometry     GetWindowGeometryCmd     `cmd:"" help:"Get the geometry (size and position) of the window with the specified UUID. The data is returned in the format required for the set-window-geometry command (x y width height)."`
-	GetWorkspace          GetWorkspaceCmd          `cmd:"" help:"Get the ID of the active workspace."`
-	SetWorkspace          SetWorkspaceCmd          `cmd:"" help:"Switch to the workspace with the specified ID."`
-	ActivateWindow        ActivateWindowCmd        `cmd:"" help:"Activate the window with the provided UUID, if such a window exists."`
-	SetWindowSize         SetWindowSizeCmd         `cmd:"" help:"Set the size of the window with the provided UUID."`
-	SetWindowPosition     SetWindowPosCmd          `cmd:"" help:"Set the position of the window with the provided UUID."`
-	SetWindowGeometry     SetWindowGeometryCmd     `cmd:"" help:"Change geometry of the window with the provided UUID."`
-	SetWindowWorkspace    SetWindowWorkspaceCmd    `cmd:"" help:"Send the window with the specified UUID to the workspace with the specified number."`
-	SetWindowProperty     SetWindowPropertyCmd     `cmd:"" help:"Change the value of a property on a window with the specified UUID."`
-	CloseWindow           CloseWindowCmd           `cmd:"" help:"Close the window with the provided UUID."`
-	RunCustomScript       RunCustomScriptCmd       `cmd:"" help:"Run a custom script. Supports up to six optional parameters."`
-	GetMousePosition      MousePosCmd              `cmd:"" help:"Return the absolute position of the mouse cursor."`
-	ListOutputs           ListOutputsCmd           `cmd:"" help:"Return the list of enabled outputs."`
-	GetActiveOutput       GetActiveOutputCmd       `cmd:"" help:"Return the active output (as defined by KWin)."`
-	GetCursorOutput       GetCursorOutputCmd       `cmd:"" help:"Return the output containing the mouse cursor."`
-	GetActiveWindowOutput GetActiveWindowOutputCmd `cmd:"" help:"Return the output containing the geometric centre of the active window."`
-	GetOutputGeometry     GetOutputGeometryCmd     `cmd:"" help:"Return the geometry (size and position) of the specified output. The data is returned in the following format: x y width height."`
-	GetWindowOpacity      GetWindowOpacityCmd      `cmd:"" help:"Return the opacity of the specified window (from 0.0 to 1.0)."`
-	SetWindowOpacity      SetWindowOpacityCmd      `cmd:"" help:"Set the opacity of the window with the provided UUID, if such a window exists."`
-	IncreaseWindowOpacity IncreaseWindowOpacityCmd `cmd:"" help:"Increase the opacity of the window with the provided UUID by 0.05. Opacity can't be set higher than 1.0."`
-	DecreaseWindowOpacity DecreaseWindowOpacityCmd `cmd:"" help:"Decrease the opacity of the window with the provided UUID by 0.05. Opacity can't be set lower than 0.1."`
+	List                      ListCmd                      `cmd:"" help:"List all windows. The data is returned as tab-separated rows containing the window's UUID, resourceClass and resourceName. Each window is represented by a separate row."`
+	Find                      FindCmd                      `cmd:"" help:"Search for windows using a case-insensitive regular expression."`
+	GetActiveWindow           GetActiveWindowCmd           `cmd:"" help:"Get the UUID of the active window."`
+	GetWindowGeometry         GetWindowGeometryCmd         `cmd:"" help:"Get the geometry (size and position) of the window with the specified UUID. The data is returned in the format required for the set-window-geometry command (x y width height)."`
+	GetWorkspace              GetWorkspaceCmd              `cmd:"" help:"Get the ID of the active workspace."`
+	SetWorkspace              SetWorkspaceCmd              `cmd:"" help:"Switch to the workspace with the specified ID."`
+	ActivateWindow            ActivateWindowCmd            `cmd:"" help:"Activate the window with the provided UUID, if such a window exists."`
+	SetWindowSize             SetWindowSizeCmd             `cmd:"" help:"Set the size of the window with the provided UUID."`
+	SetWindowPosition         SetWindowPosCmd              `cmd:"" help:"Set the position of the window with the provided UUID."`
+	SetWindowGeometry         SetWindowGeometryCmd         `cmd:"" help:"Change geometry of the window with the provided UUID."`
+	SetWindowWorkspace        SetWindowWorkspaceCmd        `cmd:"" help:"Send the window with the specified UUID to the workspace with the specified number."`
+	SetWindowProperty         SetWindowPropertyCmd         `cmd:"" help:"Change the value of a property on a window with the specified UUID."`
+	CloseWindow               CloseWindowCmd               `cmd:"" help:"Close the window with the provided UUID."`
+	RunCustomScript           RunCustomScriptCmd           `cmd:"" help:"Run a custom script. Supports up to six optional parameters."`
+	GetMousePosition          MousePosCmd                  `cmd:"" help:"Return the absolute position of the mouse cursor."`
+	ListOutputs               ListOutputsCmd               `cmd:"" help:"Return the list of enabled outputs."`
+	GetActiveOutput           GetActiveOutputCmd           `cmd:"" help:"Return the active output (as defined by KWin)."`
+	GetCursorOutput           GetCursorOutputCmd           `cmd:"" help:"Return the output containing the mouse cursor."`
+	GetActiveWindowOutput     GetActiveWindowOutputCmd     `cmd:"" help:"Return the output containing the geometric centre of the active window."`
+	GetOutputGeometry         GetOutputGeometryCmd         `cmd:"" help:"Return the geometry (size and position) of the specified output. The data is returned in the following format: x y width height."`
+	GetWindowOpacity          GetWindowOpacityCmd          `cmd:"" help:"Return the opacity of the specified window (from 0.0 to 1.0)."`
+	SetWindowOpacity          SetWindowOpacityCmd          `cmd:"" help:"Set the opacity of the window with the provided UUID, if such a window exists."`
+	IncreaseWindowOpacity     IncreaseWindowOpacityCmd     `cmd:"" help:"Increase the opacity of the window with the provided UUID by 0.05. Opacity can't be set higher than 1.0."`
+	DecreaseWindowOpacity     DecreaseWindowOpacityCmd     `cmd:"" help:"Decrease the opacity of the window with the provided UUID by 0.05. Opacity can't be set lower than 0.1."`
+	SetWindowGeometryRelative SetWindowGeometryRelativeCmd `cmd:"" help:"Change the geometry of the window with the provided UUID relative to the screen dimensions (in percent)."`
 }
 
 // parameters that are passed to the script template
@@ -82,6 +83,10 @@ type ScriptParams struct {
 	ClientArea            bool
 	OutputName            string
 	Opacity               float64
+	RelativeX             float64
+	RelativeY             float64
+	RelativeWidth         float64
+	RelativeHeight        float64
 }
 
 type ScriptPackage struct {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ type CLI struct {
 	SetWindowOpacity          SetWindowOpacityCmd          `cmd:"" help:"Set the opacity of the window with the provided UUID, if such a window exists."`
 	IncreaseWindowOpacity     IncreaseWindowOpacityCmd     `cmd:"" help:"Increase the opacity of the window with the provided UUID by 0.05. Opacity can't be set higher than 1.0."`
 	DecreaseWindowOpacity     DecreaseWindowOpacityCmd     `cmd:"" help:"Decrease the opacity of the window with the provided UUID by 0.05. Opacity can't be set lower than 0.1."`
-	SetWindowGeometryRelative SetWindowGeometryRelativeCmd `cmd:"" help:"Change the geometry of the window with the provided UUID relative to the screen dimensions (in percent)."`
+	SetWindowGeometryRelative SetWindowGeometryRelativeCmd `cmd:"" help:"Change the geometry of the window with the provided UUID relative to the screen's client area dimensions (in percent)."`
+	SetWindowSizeRelative     SetWindowSizeRelativeCmd     `cmd:"" help:"Change the size of the window with the provided UUID relative to the screen's client area dimensions (in percent)."`
+	SetWindowPositionRelative SetWindowPositionRelativeCmd `cmd:"" help:"Change the position of the window with the provided UUID relative to the screen's client area dimensions (in percent)."`
 }
 
 // parameters that are passed to the script template

--- a/main_test.go
+++ b/main_test.go
@@ -106,6 +106,24 @@ func TestCommandRunMethods(t *testing.T) {
 			wantParams:   ScriptParams{Uuid: "window-id", X: 10, Y: 20, Width: 640, Height: 480},
 		},
 		{
+			name: "set window geometry relative",
+			command: &SetWindowGeometryRelativeCmd{
+				Uuid:           "window-id",
+				RelativeX:      10.5,
+				RelativeY:      20.25,
+				RelativeWidth:  66.7,
+				RelativeHeight: 50,
+			},
+			wantTemplate: initialTemplate + JS_SET_WINDOW_GEOMETRY_RELATIVE,
+			wantParams: ScriptParams{
+				Uuid:           "window-id",
+				RelativeX:      10.5,
+				RelativeY:      20.25,
+				RelativeWidth:  66.7,
+				RelativeHeight: 50,
+			},
+		},
+		{
 			name:         "set window workspace",
 			command:      &SetWindowWorkspaceCmd{Uuid: "window-id", WorkspaceId: 3},
 			wantTemplate: initialTemplate + JS_SET_WINDOW_WORKSPACE,

--- a/main_test.go
+++ b/main_test.go
@@ -124,6 +124,34 @@ func TestCommandRunMethods(t *testing.T) {
 			},
 		},
 		{
+			name: "set window size relative",
+			command: &SetWindowSizeRelativeCmd{
+				Uuid:           "window-id",
+				RelativeWidth:  66.7,
+				RelativeHeight: 50,
+			},
+			wantTemplate: initialTemplate + JS_SET_WINDOW_SIZE_RELATIVE,
+			wantParams: ScriptParams{
+				Uuid:           "window-id",
+				RelativeWidth:  66.7,
+				RelativeHeight: 50,
+			},
+		},
+		{
+			name: "set window position relative",
+			command: &SetWindowPositionRelativeCmd{
+				Uuid:      "window-id",
+				RelativeX: 10.5,
+				RelativeY: 20.25,
+			},
+			wantTemplate: initialTemplate + JS_SET_WINDOW_POSITION_RELATIVE,
+			wantParams: ScriptParams{
+				Uuid:      "window-id",
+				RelativeX: 10.5,
+				RelativeY: 20.25,
+			},
+		},
+		{
 			name:         "set window workspace",
 			command:      &SetWindowWorkspaceCmd{Uuid: "window-id", WorkspaceId: 3},
 			wantTemplate: initialTemplate + JS_SET_WINDOW_WORKSPACE,

--- a/scripts.go
+++ b/scripts.go
@@ -366,6 +366,35 @@ if (!targetWindow) {
 
 `
 
+var JS_SET_WINDOW_GEOMETRY_RELATIVE string = `debugLog(scriptName + " executing JS_SET_WINDOW_GEOMETRY_RELATIVE");
+
+let area;
+const targetWindow = workspace.windowList().find(
+    (window) => window.internalId == {{jsString .Uuid}}
+);
+if (targetWindow) {
+    const output = targetWindow.output;
+    const desktop = workspace.currentDesktopForScreen(output);
+    area = workspace.clientArea(KWin.MaximizeArea, output, desktop);
+
+    const newGeometry = Object.assign({}, targetWindow.frameGeometry);
+    newGeometry.width = Math.round(area.width * {{.RelativeWidth}} / 100);
+    newGeometry.height = Math.round(area.height * {{.RelativeHeight}} / 100);
+    newGeometry.x = area.x + Math.round(area.width * {{.RelativeX}} / 100);
+    newGeometry.y = area.y + Math.round(area.height * {{.RelativeY}} / 100);
+
+    debugLog("Setting geometry of window with UUID=" + {{jsString .Uuid}} +
+        " to: X=" + newGeometry.x +
+        " Y=" + newGeometry.y +
+        " width=" + newGeometry.width +
+        " height=" + newGeometry.height);
+    targetWindow.frameGeometry = newGeometry;
+} else {
+    returnError("Window not found: " + {{jsString .Uuid}})
+}
+
+`
+
 var JS_FOOTER string = `close();
 debugLog(scriptName + " END");
 `

--- a/scripts.go
+++ b/scripts.go
@@ -395,6 +395,57 @@ if (targetWindow) {
 
 `
 
+var JS_SET_WINDOW_SIZE_RELATIVE string = `debugLog(scriptName + " executing JS_SET_WINDOW_SIZE_RELATIVE");
+
+let area;
+const targetWindow = workspace.windowList().find(
+    (window) => window.internalId == {{jsString .Uuid}}
+);
+if (targetWindow) {
+    const output = targetWindow.output;
+    const desktop = workspace.currentDesktopForScreen(output);
+    area = workspace.clientArea(KWin.MaximizeArea, output, desktop);
+
+    const newGeometry = Object.assign({}, targetWindow.frameGeometry);
+    newGeometry.width = Math.round(area.width * {{.RelativeWidth}} / 100);
+    newGeometry.height = Math.round(area.height * {{.RelativeHeight}} / 100);
+
+    debugLog("Setting size of window with UUID=" + {{jsString .Uuid}} +
+        " to: width=" + newGeometry.width +
+        " height=" + newGeometry.height);
+    targetWindow.frameGeometry = newGeometry;
+} else {
+    returnError("Window not found: " + {{jsString .Uuid}})
+}
+
+`
+
+var JS_SET_WINDOW_POSITION_RELATIVE string = `debugLog(scriptName + " executing JS_SET_WINDOW_POSITION_RELATIVE");
+
+let area;
+const targetWindow = workspace.windowList().find(
+    (window) => window.internalId == {{jsString .Uuid}}
+);
+if (targetWindow) {
+    const output = targetWindow.output;
+    const desktop = workspace.currentDesktopForScreen(output);
+    area = workspace.clientArea(KWin.MaximizeArea, output, desktop);
+
+    const newGeometry = Object.assign({}, targetWindow.frameGeometry);
+
+    newGeometry.x = area.x + Math.round(area.width * {{.RelativeX}} / 100);
+    newGeometry.y = area.y + Math.round(area.height * {{.RelativeY}} / 100);
+
+    debugLog("Setting position of window with UUID=" + {{jsString .Uuid}} +
+        " to: X=" + newGeometry.x +
+        " Y=" + newGeometry.y);
+    targetWindow.frameGeometry = newGeometry;
+} else {
+    returnError("Window not found: " + {{jsString .Uuid}})
+}
+
+`
+
 var JS_FOOTER string = `close();
 debugLog(scriptName + " END");
 `

--- a/usage.html
+++ b/usage.html
@@ -197,6 +197,8 @@ managers implementing NET_WM and EWMH specifications.
 <b>kwst get-window-geometry "$window_id"</b>
 <b>kwst set-window-geometry "$window_id" 100 100 1200 800</b>
 <b>kwst set-window-geometry-relative "$window_id" 0 0 50 100</b>
+<b>kwst set-window-size-relative "$window_id" 50 100</b>
+<b>kwst set-window-position-relative "$window_id" 25 25</b>
 </blockquote>
 
 <p>Toggle the active window's always-on-top state:
@@ -418,12 +420,32 @@ such a window exists.
 </blockquote>
 </blockquote>
 
+<blockquote><b>set-window-size-relative</b> &lt;uuid&gt; &lt;relative-width&gt; &lt;relative-height&gt;
+</blockquote>
+
+<blockquote>
+<blockquote>Set the size of the window with the provided UUID using percentages of the
+client area of the output containing the window. Relative width and height
+are clamped between 10 and 100 percent. Fractional percentages are accepted.
+</blockquote>
+</blockquote>
+
 <blockquote><b>set-window-position</b> &lt;uuid&gt; &lt;x&gt; &lt;y&gt;
 </blockquote>
 
 <blockquote>
 <blockquote>Set the position of the window with the provided UUID, provided
 that such a window exists.
+</blockquote>
+</blockquote>
+
+<blockquote><b>set-window-position-relative</b> &lt;uuid&gt; &lt;relative-x&gt; &lt;relative-y&gt;
+</blockquote>
+
+<blockquote>
+<blockquote>Set the position of the window with the provided UUID using percentages of
+the client area of the output containing the window. Relative X and Y are
+clamped between 0 and 100 percent. Fractional percentages are accepted.
 </blockquote>
 </blockquote>
 

--- a/usage.html
+++ b/usage.html
@@ -134,7 +134,7 @@
 <body>
 <header>
 <h1>KWST(1)</h1>
-<p class="header-date">2026-07-31</p>
+<p class="header-date">2026-08-01</p>
 </header>
 <section>
 <h2 id="NAME">NAME <a aria-hidden="true" href="#NAME">¶</a></h2>
@@ -196,6 +196,7 @@ managers implementing NET_WM and EWMH specifications.
 <blockquote>window_id=$(<b>kwst get-active-window</b>)
 <b>kwst get-window-geometry "$window_id"</b>
 <b>kwst set-window-geometry "$window_id" 100 100 1200 800</b>
+<b>kwst set-window-geometry-relative "$window_id" 0 0 50 100</b>
 </blockquote>
 
 <p>Toggle the active window's always-on-top state:
@@ -432,6 +433,17 @@ that such a window exists.
 <blockquote>
 <blockquote>Change geometry of the window with the provided UUID, provided
 that such a window exists.
+</blockquote>
+</blockquote>
+
+<blockquote><b>set-window-geometry-relative</b> &lt;uuid&gt; &lt;relative-x&gt; &lt;relative-y&gt; &lt;relative-width&gt; &lt;relative-height&gt;
+</blockquote>
+
+<blockquote>
+<blockquote>Change the geometry of the window with the provided UUID using percentages
+of the client area of the output containing the window. Relative X and Y are
+clamped between 0 and 100 percent. Relative width and height are clamped
+between 10 and 100 percent. Fractional percentages are accepted.
 </blockquote>
 </blockquote>
 


### PR DESCRIPTION
This PR implements three new commands for manipulating window geometry that support relative size/position:

- `set-window-geometry-relative`
- `set-window-size-relative`
- `set-window-position-relative`

All commands are relative to the dimensions of the client area of the output containing the target window.