### PR TITLE
unassign from tile before mutating window geometry

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -89,7 +89,7 @@ type SetWindowSizeCmd struct {
 }
 
 func (swsc *SetWindowSizeCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_SET_WINDOW_SIZE
+	sp.ScriptTemplate += JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_SIZE
 	sp.Params.Uuid = swsc.Uuid
 	sp.Params.Width = swsc.Width
 	sp.Params.Height = swsc.Height
@@ -103,7 +103,7 @@ type SetWindowPosCmd struct {
 }
 
 func (swpc *SetWindowPosCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_SET_WINDOW_POSITION
+	sp.ScriptTemplate += JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_POSITION
 	sp.Params.Uuid = swpc.Uuid
 	sp.Params.X = swpc.X
 	sp.Params.Y = swpc.Y
@@ -119,7 +119,7 @@ type SetWindowGeometryCmd struct {
 }
 
 func (swgc *SetWindowGeometryCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_SET_WINDOW_GEOMETRY
+	sp.ScriptTemplate += JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_GEOMETRY
 	sp.Params.Uuid = swgc.Uuid
 	sp.Params.X = swgc.X
 	sp.Params.Y = swgc.Y
@@ -320,7 +320,7 @@ func (cmd *SetWindowGeometryRelativeCmd) Validate() error {
 }
 
 func (cmd SetWindowGeometryRelativeCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_SET_WINDOW_GEOMETRY_RELATIVE
+	sp.ScriptTemplate += JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_GEOMETRY_RELATIVE
 	sp.Params.Uuid = cmd.Uuid
 	sp.Params.RelativeX = cmd.RelativeX
 	sp.Params.RelativeY = cmd.RelativeY
@@ -348,7 +348,7 @@ func (cmd *SetWindowSizeRelativeCmd) Validate() error {
 }
 
 func (cmd SetWindowSizeRelativeCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_SET_WINDOW_SIZE_RELATIVE
+	sp.ScriptTemplate += JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_SIZE_RELATIVE
 	sp.Params.Uuid = cmd.Uuid
 	sp.Params.RelativeWidth = cmd.RelativeWidth
 	sp.Params.RelativeHeight = cmd.RelativeHeight
@@ -374,7 +374,7 @@ func (cmd *SetWindowPositionRelativeCmd) Validate() error {
 }
 
 func (cmd SetWindowPositionRelativeCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_SET_WINDOW_POSITION_RELATIVE
+	sp.ScriptTemplate += JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_POSITION_RELATIVE
 	sp.Params.Uuid = cmd.Uuid
 	sp.Params.RelativeX = cmd.RelativeX
 	sp.Params.RelativeY = cmd.RelativeY
@@ -422,7 +422,7 @@ type UnsetWindowTileCmd struct {
 }
 
 func (cmd UnsetWindowTileCmd) Run(sp *ScriptPackage) error {
-	sp.ScriptTemplate += JS_TILE_HELPERS + JS_UNSET_WINDOW_TILE
+	sp.ScriptTemplate += JS_TILE_UNASSIGNMENT_HELPER + JS_UNSET_WINDOW_TILE
 	sp.Params.Uuid = cmd.Uuid
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -90,19 +90,19 @@ func TestCommandRunMethods(t *testing.T) {
 		{
 			name:         "set window size",
 			command:      &SetWindowSizeCmd{Uuid: "window-id", Width: 640, Height: 480},
-			wantTemplate: initialTemplate + JS_SET_WINDOW_SIZE,
+			wantTemplate: initialTemplate + JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_SIZE,
 			wantParams:   ScriptParams{Uuid: "window-id", Width: 640, Height: 480},
 		},
 		{
 			name:         "set window position",
 			command:      &SetWindowPosCmd{Uuid: "window-id", X: 10, Y: 20},
-			wantTemplate: initialTemplate + JS_SET_WINDOW_POSITION,
+			wantTemplate: initialTemplate + JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_POSITION,
 			wantParams:   ScriptParams{Uuid: "window-id", X: 10, Y: 20},
 		},
 		{
 			name:         "set window geometry",
 			command:      &SetWindowGeometryCmd{Uuid: "window-id", X: 10, Y: 20, Width: 640, Height: 480},
-			wantTemplate: initialTemplate + JS_SET_WINDOW_GEOMETRY,
+			wantTemplate: initialTemplate + JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_GEOMETRY,
 			wantParams:   ScriptParams{Uuid: "window-id", X: 10, Y: 20, Width: 640, Height: 480},
 		},
 		{
@@ -114,7 +114,7 @@ func TestCommandRunMethods(t *testing.T) {
 				RelativeWidth:  66.7,
 				RelativeHeight: 50,
 			},
-			wantTemplate: initialTemplate + JS_SET_WINDOW_GEOMETRY_RELATIVE,
+			wantTemplate: initialTemplate + JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_GEOMETRY_RELATIVE,
 			wantParams: ScriptParams{
 				Uuid:           "window-id",
 				RelativeX:      10.5,
@@ -130,7 +130,7 @@ func TestCommandRunMethods(t *testing.T) {
 				RelativeWidth:  66.7,
 				RelativeHeight: 50,
 			},
-			wantTemplate: initialTemplate + JS_SET_WINDOW_SIZE_RELATIVE,
+			wantTemplate: initialTemplate + JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_SIZE_RELATIVE,
 			wantParams: ScriptParams{
 				Uuid:           "window-id",
 				RelativeWidth:  66.7,
@@ -144,7 +144,7 @@ func TestCommandRunMethods(t *testing.T) {
 				RelativeX: 10.5,
 				RelativeY: 20.25,
 			},
-			wantTemplate: initialTemplate + JS_SET_WINDOW_POSITION_RELATIVE,
+			wantTemplate: initialTemplate + JS_TILE_UNASSIGNMENT_HELPER + JS_SET_WINDOW_POSITION_RELATIVE,
 			wantParams: ScriptParams{
 				Uuid:      "window-id",
 				RelativeX: 10.5,
@@ -233,7 +233,7 @@ func TestCommandRunMethods(t *testing.T) {
 		{
 			name:         "unset window tile",
 			command:      &UnsetWindowTileCmd{Uuid: "window-id"},
-			wantTemplate: initialTemplate + JS_TILE_HELPERS + JS_UNSET_WINDOW_TILE,
+			wantTemplate: initialTemplate + JS_TILE_UNASSIGNMENT_HELPER + JS_UNSET_WINDOW_TILE,
 			wantParams:   ScriptParams{Uuid: "window-id"},
 		},
 		{
@@ -601,12 +601,13 @@ func TestUUIDCommandsGuardMissingWindow(t *testing.T) {
 		name           string
 		scriptTemplate string
 		action         string
+		usesWindowID   bool
 	}{
 		{name: "get geometry", scriptTemplate: JS_GET_WINDOW_GEOMETRY, action: "returnResult(result);"},
 		{name: "activate", scriptTemplate: JS_ACTIVATE_WINDOW, action: "workspace.activeWindow = targetWindow;"},
-		{name: "set size", scriptTemplate: JS_SET_WINDOW_SIZE, action: "updateWindowGeometry(targetWindow, {"},
-		{name: "set position", scriptTemplate: JS_SET_WINDOW_POSITION, action: "updateWindowGeometry(targetWindow, {"},
-		{name: "set geometry", scriptTemplate: JS_SET_WINDOW_GEOMETRY, action: "updateWindowGeometry(targetWindow, {"},
+		{name: "set size", scriptTemplate: JS_SET_WINDOW_SIZE, action: "updateWindowGeometry(targetWindow, {", usesWindowID: true},
+		{name: "set position", scriptTemplate: JS_SET_WINDOW_POSITION, action: "updateWindowGeometry(targetWindow, {", usesWindowID: true},
+		{name: "set geometry", scriptTemplate: JS_SET_WINDOW_GEOMETRY, action: "updateWindowGeometry(targetWindow, {", usesWindowID: true},
 		{name: "set workspace", scriptTemplate: JS_SET_WINDOW_WORKSPACE, action: "targetWindow.desktops = [targetWorkspace];"},
 		{name: "set property", scriptTemplate: JS_SET_WINDOW_PROPERTY, action: "targetWindow.keepAbove = !targetWindow.keepAbove;"},
 		{name: "close", scriptTemplate: JS_CLOSE_WINDOW, action: "targetWindow.closeWindow();"},
@@ -626,12 +627,20 @@ func TestUUIDCommandsGuardMissingWindow(t *testing.T) {
 				t.Fatal(err)
 			}
 			generated := script.String()
-			for _, expected := range []string{
-				"const targetWindow = findWindow(" + quotedUUID + ");",
-				"if (!targetWindow)",
-				`returnError(ERROR_WINDOW_NOT_FOUND + ` + quotedUUID + `);`,
-				test.action,
-			} {
+			expectedParts := []string{"if (!targetWindow)", test.action}
+			if test.usesWindowID {
+				expectedParts = append(expectedParts,
+					"const windowId = "+quotedUUID+";",
+					"const targetWindow = findWindow(windowId);",
+					"returnError(ERROR_WINDOW_NOT_FOUND + windowId);",
+				)
+			} else {
+				expectedParts = append(expectedParts,
+					"const targetWindow = findWindow("+quotedUUID+");",
+					`returnError(ERROR_WINDOW_NOT_FOUND + `+quotedUUID+`);`,
+				)
+			}
+			for _, expected := range expectedParts {
 				if !strings.Contains(generated, expected) {
 					t.Errorf("generated script does not contain %q:\n%s", expected, generated)
 				}

--- a/scripts.go
+++ b/scripts.go
@@ -9,6 +9,7 @@ const scriptName = "{{.ScriptName}}";
 const ERROR_WINDOW_NOT_FOUND = "Window not found: ";
 const ERROR_OUTPUT_NOT_FOUND = "Output not found: ";
 const ERROR_TILE_NOT_FOUND = "Tile not found: ";
+const ERROR_TILE_UNASSIGNMENT_FAILED = "Could not unassign window: ";
 
 let exitCode = 0;
 
@@ -89,6 +90,23 @@ var JS_WINDOW_LIST_HELPERS string = `const formatWindowRow = (
     }
 
     return fields.join("\t");
+}
+
+`
+
+var JS_TILE_UNASSIGNMENT_HELPER = `const unassignFromTile = (targetWindow) => {
+    const tile = targetWindow.tile;
+
+    if (!tile) {
+        return true;
+    }
+
+    if (typeof tile.unmanage === "function" && tile.unmanage(targetWindow)) {
+        return true;
+    }
+
+    targetWindow.tile = null;
+    return targetWindow.tile === null;
 }
 
 `
@@ -182,21 +200,6 @@ const assignToTile = (targetWindow, tile) => {
         targetWindow.tile = tile;
         return targetWindow.tile === tile;
     }
-}
-
-const unassignFromTile = (targetWindow) => {
-    const tile = targetWindow.tile;
-
-    if (!tile) {
-        return true;
-    }
-
-    if (typeof tile.unmanage === "function" && tile.unmanage(targetWindow)) {
-        return true;
-    }
-
-    targetWindow.tile = null;
-    return targetWindow.tile === null;
 }
 
 const isOnCurrentDesktop = (targetWindow, targetOutput) => {
@@ -333,47 +336,62 @@ if (!targetWindow) {
 
 var JS_SET_WINDOW_SIZE string = `debugLog(scriptName + " executing JS_SET_WINDOW_SIZE");
 
-const targetWindow = findWindow({{jsString .Uuid}});
+const windowId = {{jsString .Uuid}};
+const targetWindow = findWindow(windowId);
 if (!targetWindow) {
-    returnError(ERROR_WINDOW_NOT_FOUND + {{jsString .Uuid}});
+    returnError(ERROR_WINDOW_NOT_FOUND + windowId);
 } else {
-    debugLog("New size for window with UUID=" + {{jsString .Uuid}} + ": width={{.Width}}, height={{.Height}}");
-    updateWindowGeometry(targetWindow, {
-        width: {{.Width}},
-        height: {{.Height}},
-    });
+    debugLog("New size for window with UUID=" + windowId + ": width={{.Width}}, height={{.Height}}");
+    if (!unassignFromTile(targetWindow)) {
+        returnError(ERROR_TILE_UNASSIGNMENT_FAILED + windowId);
+    } else {
+        updateWindowGeometry(targetWindow, {
+            width: {{.Width}},
+            height: {{.Height}},
+        });
+    }
 }
 
 `
 
 var JS_SET_WINDOW_POSITION string = `debugLog(scriptName + " executing JS_SET_WINDOW_POSITION");
 
-const targetWindow = findWindow({{jsString .Uuid}});
+const windowId = {{jsString .Uuid}};
+const targetWindow = findWindow(windowId);
 if (!targetWindow) {
-    returnError(ERROR_WINDOW_NOT_FOUND + {{jsString .Uuid}});
+    returnError(ERROR_WINDOW_NOT_FOUND + windowId);
 } else {
-    debugLog("New position for window with UUID=" + {{jsString .Uuid}} + ": X={{.X}}, Y={{.Y}}");
-    updateWindowGeometry(targetWindow, {
-        x: {{.X}},
-        y: {{.Y}}
-    });
+    debugLog("New position for window with UUID=" + windowId + ": X={{.X}}, Y={{.Y}}");
+    if (!unassignFromTile(targetWindow)) {
+        returnError(ERROR_TILE_UNASSIGNMENT_FAILED + windowId);
+    } else {
+        updateWindowGeometry(targetWindow, {
+            x: {{.X}},
+            y: {{.Y}}
+        });
+    }
 }
 
 `
 
 var JS_SET_WINDOW_GEOMETRY string = `debugLog(scriptName + " executing JS_SET_WINDOW_GEOMETRY");
 
-const targetWindow = findWindow({{jsString .Uuid}});
+const windowId = {{jsString .Uuid}};
+const targetWindow = findWindow(windowId);
 if (!targetWindow) {
-    returnError(ERROR_WINDOW_NOT_FOUND + {{jsString .Uuid}});
+    returnError(ERROR_WINDOW_NOT_FOUND + windowId);
 } else {
-    debugLog("New geometry for window with UUID=" + {{jsString .Uuid}} + ": X={{.X}}, Y={{.Y}}, width={{.Width}}, height={{.Height}}");
-    updateWindowGeometry(targetWindow, {
-        width: {{.Width}},
-        height: {{.Height}},
-        x: {{.X}},
-        y: {{.Y}}
-    });
+    debugLog("New geometry for window with UUID=" + windowId + ": X={{.X}}, Y={{.Y}}, width={{.Width}}, height={{.Height}}");
+    if (!unassignFromTile(targetWindow)) {
+        returnError(ERROR_TILE_UNASSIGNMENT_FAILED + windowId);
+    } else {
+        updateWindowGeometry(targetWindow, {
+            width: {{.Width}},
+            height: {{.Height}},
+            x: {{.X}},
+            y: {{.Y}}
+        });
+    }
 }
 
 `
@@ -553,7 +571,8 @@ if (!targetWindow) {
 
 var JS_SET_WINDOW_GEOMETRY_RELATIVE string = `debugLog(scriptName + " executing JS_SET_WINDOW_GEOMETRY_RELATIVE");
 
-const targetWindow = findWindow({{jsString .Uuid}});
+const windowId = {{jsString .Uuid}};
+const targetWindow = findWindow(windowId);
 if (targetWindow) {
     const area = clientAreaForWindow(targetWindow);
 
@@ -562,63 +581,77 @@ if (targetWindow) {
     const x = area.x + Math.round(area.width * {{.RelativeX}} / 100);
     const y = area.y + Math.round(area.height * {{.RelativeY}} / 100);
 
-    debugLog("Setting geometry of window with UUID=" + {{jsString .Uuid}} +
+    debugLog("Setting geometry of window with UUID=" + windowId +
         " to: X=" + x +
         " Y=" + y +
         " width=" + width +
         " height=" + height);
-    updateWindowGeometry(targetWindow, {
-        x,
-        y,
-        width,
-        height
-    });
+    if (!unassignFromTile(targetWindow)) {
+        returnError(ERROR_TILE_UNASSIGNMENT_FAILED + windowId);
+    } else {
+        updateWindowGeometry(targetWindow, {
+            x,
+            y,
+            width,
+            height
+        });
+    }
 } else {
-    returnError(ERROR_WINDOW_NOT_FOUND + {{jsString .Uuid}})
+    returnError(ERROR_WINDOW_NOT_FOUND + windowId);
 }
 
 `
 
 var JS_SET_WINDOW_SIZE_RELATIVE string = `debugLog(scriptName + " executing JS_SET_WINDOW_SIZE_RELATIVE");
 
-const targetWindow = findWindow({{jsString .Uuid}});
+const windowId = {{jsString .Uuid}};
+const targetWindow = findWindow(windowId);
 if (targetWindow) {
     const area = clientAreaForWindow(targetWindow);
 
     const width = Math.round(area.width * {{.RelativeWidth}} / 100);
     const height = Math.round(area.height * {{.RelativeHeight}} / 100);
 
-    debugLog("Setting size of window with UUID=" + {{jsString .Uuid}} +
+    debugLog("Setting size of window with UUID=" + windowId +
         " to: width=" + width +
         " height=" + height);
-    updateWindowGeometry(targetWindow, {
-        width,
-        height
-    });
+    if (!unassignFromTile(targetWindow)) {
+        returnError(ERROR_TILE_UNASSIGNMENT_FAILED + windowId);
+    } else {
+        updateWindowGeometry(targetWindow, {
+            width,
+            height
+        });
+    }
 } else {
-    returnError(ERROR_WINDOW_NOT_FOUND + {{jsString .Uuid}})
+    returnError(ERROR_WINDOW_NOT_FOUND + windowId);
 }
 
 `
 
 var JS_SET_WINDOW_POSITION_RELATIVE string = `debugLog(scriptName + " executing JS_SET_WINDOW_POSITION_RELATIVE");
 
-const targetWindow = findWindow({{jsString .Uuid}});
+const windowId = {{jsString .Uuid}};
+const targetWindow = findWindow(windowId);
 if (targetWindow) {
     const area = clientAreaForWindow(targetWindow);
 
     const x = area.x + Math.round(area.width * {{.RelativeX}} / 100);
     const y = area.y + Math.round(area.height * {{.RelativeY}} / 100);
 
-    debugLog("Setting position of window with UUID=" + {{jsString .Uuid}} +
+    debugLog("Setting position of window with UUID=" + windowId +
         " to: X=" + x +
         " Y=" + y);
-    updateWindowGeometry(targetWindow, {
-        x,
-        y
-    });
+    if (!unassignFromTile(targetWindow)) {
+        returnError(ERROR_TILE_UNASSIGNMENT_FAILED + windowId);
+    } else {
+        updateWindowGeometry(targetWindow, {
+            x,
+            y
+        });
+    }
 } else {
-    returnError(ERROR_WINDOW_NOT_FOUND + {{jsString .Uuid}})
+    returnError(ERROR_WINDOW_NOT_FOUND + windowId);
 }
 
 `


### PR DESCRIPTION
If a window is assigned to a tile, changing its geometry does not remove its tile association. This means that the tile is still managing the window geometry, and if the tile geometry is changed, the window would snap back to the tile.

To prevent this from happening, we need to explicitly unassign windows from tiles before mutating their geometry.