### PR TITLE
replace three D-Bus methods with one atomic call

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ Please see the [Go text/template documentation](https://pkg.go.dev/text/template
 
 ## Debugging KWin scripts
 
-The `kwst-debug-listener` executable implements the same D-Bus callback methods
-as **kwst** (`Msg`, `Close`, and `CloseWithStatus`), but prints every call it
-receives instead of processing the result or exiting. This makes it possible to
+The `kwst-debug-listener` executable implements the same `Complete` D-Bus
+callback as **kwst**, but prints every call it receives instead of processing
+the result or exiting. This makes it possible to
 debug scripts interactively with KWin's scripting console.
 
 Build and start the listener:
@@ -226,10 +226,10 @@ plasma-interactiveconsole --kwin
 ```
 
 Use the displayed address as `dbusAddr` in the script being tested, then run the
-script in the console. Calls to the listener's D-Bus methods are printed to its
-standard output with timestamps. `Close()` and `CloseWithStatus()` are logged
-without stopping the listener, so the script can be run repeatedly. Press `q`
-in the listener's terminal to quit.
+script in the console. Calls to the listener's `Complete` D-Bus method are
+printed to its standard output with timestamps without stopping the listener,
+so the script can be run repeatedly. Press `q` in the listener's terminal to
+quit.
 
 ## Installation
 

--- a/_examples/custom-script-1.js
+++ b/_examples/custom-script-1.js
@@ -6,6 +6,9 @@ const scriptName = "{{.ScriptName}}";
 
 let exitCode = 0;
 
+const results = [];
+const errors = [];
+
 const debugLog = (msg) => {
     if (debug) {
         print(msg.toString());
@@ -13,19 +16,19 @@ const debugLog = (msg) => {
 }
 
 const close = () => {
-    debugLog("Calling CloseWithStatus() on " + dbusAddr);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "CloseWithStatus", exitCode);
+    debugLog("Calling Complete() on " + dbusAddr);
+    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Complete", exitCode, results.join("\n"), errors.join("\n"));
 }
 
 const returnResult = (msgBody) => {
     debugLog("RESULT: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "result", msgBody.toString());
+    results.push(msgBody.toString());
 }
 
 const returnError = (msgBody) => {
     exitCode = 1;
     debugLog("ERROR: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "error", msgBody.toString());
+    errors.push("KWin script returned an error: " + msgBody.toString());
 }
 
 

--- a/_examples/custom-script-2.js
+++ b/_examples/custom-script-2.js
@@ -6,6 +6,9 @@ const scriptName = "{{.ScriptName}}";
 
 let exitCode = 0;
 
+const results = [];
+const errors = [];
+
 const debugLog = (msg) => {
     if (debug) {
         print(msg.toString());
@@ -13,19 +16,19 @@ const debugLog = (msg) => {
 }
 
 const close = () => {
-    debugLog("Calling CloseWithStatus() on " + dbusAddr);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "CloseWithStatus", exitCode);
+    debugLog("Calling Complete() on " + dbusAddr);
+    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Complete", exitCode, results.join("\n"), errors.join("\n"));
 }
 
 const returnResult = (msgBody) => {
     debugLog("RESULT: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "result", msgBody.toString());
+    results.push(msgBody.toString());
 }
 
 const returnError = (msgBody) => {
     exitCode = 1;
     debugLog("ERROR: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "error", msgBody.toString());
+    errors.push("KWin script returned an error: " + msgBody.toString());
 }
 
 

--- a/cmd/kwst-debug-listener/main.go
+++ b/cmd/kwst-debug-listener/main.go
@@ -29,18 +29,8 @@ func newDebugListener(stdout io.Writer) *debugListener {
 	return &debugListener{stdout: stdout}
 }
 
-func (l *debugListener) Msg(msgType, message string) *dbus.Error {
-	l.printf("Msg() was called, type: %s, message:\n%s\n", msgType, message)
-	return nil
-}
-
-func (l *debugListener) Close() *dbus.Error {
-	l.printf("Close() was called\n")
-	return nil
-}
-
-func (l *debugListener) CloseWithStatus(status int32) *dbus.Error {
-	l.printf("CloseWithStatus() was called, reported status: %d\n", status)
+func (l *debugListener) Complete(status int32, stdout, stderr string) *dbus.Error {
+	l.printf("Complete() was called, reported status: %d\nstdout:\n%s\nstderr:\n%s\n", status, stdout, stderr)
 	return nil
 }
 

--- a/cmd/kwst-debug-listener/main_test.go
+++ b/cmd/kwst-debug-listener/main_test.go
@@ -40,20 +40,13 @@ func TestDebugListenerPrintsCalls(t *testing.T) {
 	var output bytes.Buffer
 	listener := newDebugListener(&output)
 
-	if err := listener.Msg("result", "window-id"); err != nil {
-		t.Fatalf("Msg returned a D-Bus error: %v", err)
-	}
-	if err := listener.Close(); err != nil {
-		t.Fatalf("Close returned a D-Bus error: %v", err)
-	}
-	if err := listener.CloseWithStatus(23); err != nil {
-		t.Fatalf("CloseWithStatus returned a D-Bus error: %v", err)
+	if err := listener.Complete(23, "window-id", "script failed"); err != nil {
+		t.Fatalf("Complete returned a D-Bus error: %v", err)
 	}
 
 	want := regexp.MustCompile(
-		`^\[\d{2}:\d{2}:\d{2}\] Msg\(\) was called, type: result, message:\nwindow-id\n` +
-			`\[\d{2}:\d{2}:\d{2}\] Close\(\) was called\n` +
-			`\[\d{2}:\d{2}:\d{2}\] CloseWithStatus\(\) was called, reported status: 23\n$`,
+		`^\[\d{2}:\d{2}:\d{2}\] Complete\(\) was called, reported status: 23\n` +
+			`stdout:\nwindow-id\nstderr:\nscript failed\n$`,
 	)
 	if got := output.String(); !want.MatchString(got) {
 		t.Fatalf("output = %q, want timestamped listener calls", got)
@@ -63,9 +56,7 @@ func TestDebugListenerPrintsCalls(t *testing.T) {
 func TestDebugListenerDBusMethods(t *testing.T) {
 	methods := introspect.Methods(newDebugListener(&bytes.Buffer{}))
 	want := map[string][]string{
-		"Close":           {},
-		"CloseWithStatus": {"i"},
-		"Msg":             {"s", "s"},
+		"Complete": {"i", "s", "s"},
 	}
 
 	if len(methods) != len(want) {

--- a/custom-script-template.js
+++ b/custom-script-template.js
@@ -6,6 +6,9 @@ const scriptName = "{{.ScriptName}}";
 
 let exitCode = 0;
 
+const results = [];
+const errors = [];
+
 // use this function to print debug messages to the system log.
 // the messages will be printed only if kwst is called with the `--debug` flag.
 // to make sure that debug messages are added to the system log, 
@@ -22,15 +25,15 @@ const debugLog = (msg) => {
 // it tells kwst that the script is done and terminates the execution
 // of the program.
 const close = () => {
-    debugLog("Calling CloseWithStatus() on " + dbusAddr);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "CloseWithStatus", exitCode);
+    debugLog("Calling Complete() on " + dbusAddr);
+    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Complete", exitCode, results.join("\n"), errors.join("\n"));
 }
 
 // use this function to return results back to kwst. The results
 // will be printed to stdout
 const returnResult = (msgBody) => {
     debugLog("RESULT: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "result", msgBody.toString());
+    results.push(msgBody.toString());
 }
 
 // use this function to return errors back to kwst. The errors
@@ -38,7 +41,7 @@ const returnResult = (msgBody) => {
 const returnError = (msgBody) => {
     exitCode = 1;
     debugLog("ERROR: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "error", msgBody.toString());
+    errors.push("KWin script returned an error: " + msgBody.toString());
 }
 
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"text/template"
 	"time"
 
@@ -134,7 +133,6 @@ func prepareScript(w io.Writer, sp ScriptPackage) error {
 // define the DBus object for exporting
 type Server struct {
 	done   chan int
-	failed atomic.Bool
 	once   sync.Once
 	stdout io.Writer
 	stderr io.Writer
@@ -148,34 +146,15 @@ func newServer(stdout, stderr io.Writer) *Server {
 	}
 }
 
-func (s *Server) Msg(msgType, message string) *dbus.Error {
-	if msgType == "result" {
-		fmt.Fprintln(s.stdout, message)
-	} else if msgType == "error" {
-		s.failed.Store(true)
-		fmt.Fprintln(s.stderr, "KWin script returned an error:", message)
+func (s *Server) Complete(exitCode int32, stdout, stderr string) *dbus.Error {
+	if stdout != "" {
+		fmt.Fprintln(s.stdout, stdout)
 	}
-	return nil
-}
+	if stderr != "" {
+		fmt.Fprintln(s.stderr, stderr)
+	}
 
-// Close is retained for compatibility with existing custom scripts. New
-// scripts should use CloseWithStatus so completion does not depend on the
-// ordering of separate Msg and Close calls.
-func (s *Server) Close() *dbus.Error {
-	exitCode := 0
-	if s.failed.Load() {
-		exitCode = 1
-	}
-	s.finish(exitCode)
-	return nil
-}
-
-func (s *Server) CloseWithStatus(exitCode int32) *dbus.Error {
-	status := normalizeExitCode(int(exitCode))
-	if s.failed.Load() {
-		status = 1
-	}
-	s.finish(status)
+	s.finish(normalizeExitCode(int(exitCode)))
 	return nil
 }
 
@@ -207,7 +186,7 @@ func waitForCompletion(done <-chan int, timeout time.Duration, stderr io.Writer)
 	case exitCode := <-done:
 		return normalizeExitCode(exitCode)
 	case <-timer.C:
-		fmt.Fprintln(stderr, "Close() call not received from KWin scripting. Timing out...")
+		fmt.Fprintln(stderr, "Complete() call not received from KWin scripting. Timing out...")
 		return 124
 	}
 }
@@ -317,8 +296,6 @@ func run() int {
 
 	exitCode := waitForCompletion(s.done, scriptTimeout(debug), os.Stderr)
 
-	// give it some time to finish receiving and processing DBus messages
-	time.Sleep(5 * time.Millisecond)
 	if call := kwinConn.Call("unloadScript", 0, sp.Params.ScriptName); call.Err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to unload KWin script:", call.Err)
 		return 1

--- a/main_test.go
+++ b/main_test.go
@@ -711,41 +711,44 @@ func TestUUIDCommandsGuardMissingWindow(t *testing.T) {
 	}
 }
 
-func TestServerCloseWithStatus(t *testing.T) {
-	server := newServer(io.Discard, io.Discard)
-	if err := server.CloseWithStatus(1); err != nil {
-		t.Fatalf("CloseWithStatus returned a D-Bus error: %v", err)
+func TestServerComplete(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	server := newServer(&stdout, &stderr)
+
+	if err := server.Complete(23, "first\nsecond", "script failed"); err != nil {
+		t.Fatalf("Complete returned a D-Bus error: %v", err)
 	}
 
-	if exitCode := <-server.done; exitCode != 1 {
-		t.Fatalf("exit code = %d, want 1", exitCode)
+	if got, want := stdout.String(), "first\nsecond\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := stderr.String(), "script failed\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if exitCode := <-server.done; exitCode != 23 {
+		t.Fatalf("exit code = %d, want 23", exitCode)
 	}
 }
 
-func TestCloseWithStatusDBusSignature(t *testing.T) {
-	for _, method := range introspect.Methods(newServer(io.Discard, io.Discard)) {
-		if method.Name != "CloseWithStatus" {
-			continue
-		}
-		if len(method.Args) != 1 || method.Args[0].Type != "i" || method.Args[0].Direction != "in" {
-			t.Fatalf("CloseWithStatus D-Bus arguments = %#v, want one INT32 input", method.Args)
-		}
-		return
-	}
-	t.Fatal("CloseWithStatus is not exported over D-Bus")
-}
-
-func TestLegacyCloseReportsPriorScriptError(t *testing.T) {
-	server := newServer(io.Discard, io.Discard)
-	if err := server.Msg("error", "invalid workspace"); err != nil {
-		t.Fatalf("Msg returned a D-Bus error: %v", err)
-	}
-	if err := server.Close(); err != nil {
-		t.Fatalf("Close returned a D-Bus error: %v", err)
+func TestServerDBusMethods(t *testing.T) {
+	methods := introspect.Methods(newServer(io.Discard, io.Discard))
+	if len(methods) != 1 {
+		t.Fatalf("exported method count = %d, want 1: %#v", len(methods), methods)
 	}
 
-	if exitCode := <-server.done; exitCode != 1 {
-		t.Fatalf("exit code = %d, want 1", exitCode)
+	method := methods[0]
+	if method.Name != "Complete" {
+		t.Fatalf("exported method = %q, want Complete", method.Name)
+	}
+	wantArgs := []string{"i", "s", "s"}
+	if len(method.Args) != len(wantArgs) {
+		t.Fatalf("Complete argument count = %d, want %d", len(method.Args), len(wantArgs))
+	}
+	for i, arg := range method.Args {
+		if arg.Type != wantArgs[i] || arg.Direction != "in" {
+			t.Errorf("Complete argument %d = %#v, want input type %q", i, arg, wantArgs[i])
+		}
 	}
 }
 
@@ -774,7 +777,7 @@ func TestGeneratedScriptReportsExitStatus(t *testing.T) {
 	for _, expected := range []string{
 		"let exitCode = 0;",
 		"exitCode = 1;",
-		`"CloseWithStatus", exitCode`,
+		`"Complete", exitCode, results.join("\n"), errors.join("\n")`,
 	} {
 		if !strings.Contains(JS_HEADER, expected) {
 			t.Errorf("JS_HEADER does not contain %q", expected)

--- a/scripts.go
+++ b/scripts.go
@@ -13,6 +13,9 @@ const ERROR_TILE_UNASSIGNMENT_FAILED = "Could not unassign window: ";
 
 let exitCode = 0;
 
+const results = [];
+const errors = [];
+
 const debugLog = (msg) => {
     if (debug) {
         print(msg.toString());
@@ -20,19 +23,19 @@ const debugLog = (msg) => {
 }
 
 const close = () => {
-    debugLog("Calling CloseWithStatus() on " + dbusAddr);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "CloseWithStatus", exitCode);
+    debugLog("Calling Complete() on " + dbusAddr);
+    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Complete", exitCode, results.join("\n"), errors.join("\n"));
 }
 
 const returnResult = (msgBody) => {
     debugLog("RESULT: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "result", msgBody.toString());
+    results.push(msgBody.toString());
 }
 
 const returnError = (msgBody) => {
     exitCode = 1;
     debugLog("ERROR: " + msgBody);
-    callDBus(dbusAddr, "/net/prsv/kwst", "net.prsv.kwst", "Msg", "error", msgBody.toString());
+    errors.push("KWin script returned an error: " + msgBody.toString());
 }
 
 const findWindow = (uuid) => {


### PR DESCRIPTION
This change replaces three existing D-Bus methods (`Msg`, `Close`, and `CloseWithStatus`) with a single atomic call. This eliminates the race between closing the server and processing messages, and allows me to get rid of the 5ms delay before quitting. 